### PR TITLE
Add support for custom Braintrust data planes

### DIFF
--- a/skills/using-braintrust/SKILL.md
+++ b/skills/using-braintrust/SKILL.md
@@ -122,6 +122,14 @@ Create a `.env` file in your project directory:
 BRAINTRUST_API_KEY=your-api-key-here
 ```
 
+### Custom data planes
+
+If your organization uses a dedicated Braintrust data plane, also set:
+
+```
+BRAINTRUST_APP_URL=https://your-dataplane.example.com
+```
+
 ## Writing evaluation code (SDK)
 
 For custom evaluation logic, use the SDK directly.

--- a/skills/using-braintrust/scripts/log_data.py
+++ b/skills/using-braintrust/scripts/log_data.py
@@ -53,6 +53,11 @@ def main():
     # Import after loading env so braintrust picks up the key
     import braintrust
 
+    # Support custom data planes via BRAINTRUST_APP_URL
+    app_url = os.environ.get("BRAINTRUST_APP_URL")
+    if app_url:
+        braintrust.login(app_url=app_url)
+
     logger = braintrust.init_logger(project=args.project)
 
     # Batch logging

--- a/skills/using-braintrust/scripts/query_logs.py
+++ b/skills/using-braintrust/scripts/query_logs.py
@@ -40,11 +40,17 @@ def load_api_key() -> str:
     return api_key
 
 
+def get_api_base_url() -> str:
+    """Get API base URL, using BRAINTRUST_APP_URL if set for custom data planes."""
+    return os.environ.get("BRAINTRUST_APP_URL", "https://api.braintrust.dev")
+
+
 def get_project_id(project_name: str, api_key: str) -> str:
     """Get project ID from name."""
     headers = {"Authorization": f"Bearer {api_key}"}
+    base_url = get_api_base_url()
     resp = requests.get(
-        "https://api.braintrust.dev/v1/project",
+        f"{base_url}/v1/project",
         headers=headers,
         params={"project_name": project_name},
     )
@@ -54,7 +60,7 @@ def get_project_id(project_name: str, api_key: str) -> str:
             return projects[0]["id"]
 
     # Try listing all projects and matching by name
-    resp = requests.get("https://api.braintrust.dev/v1/project", headers=headers)
+    resp = requests.get(f"{base_url}/v1/project", headers=headers)
     if resp.status_code == 200:
         projects = resp.json().get("objects", [])
         for p in projects:
@@ -72,6 +78,7 @@ def get_project_id(project_name: str, api_key: str) -> str:
 def run_sql(project_id: str, query: str, api_key: str) -> list[dict]:
     """Execute SQL query against Braintrust logs."""
     headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    base_url = get_api_base_url()
 
     # Replace "FROM logs" with the project-scoped source
     full_query = re.sub(
@@ -79,7 +86,7 @@ def run_sql(project_id: str, query: str, api_key: str) -> list[dict]:
     )
 
     resp = requests.post(
-        "https://api.braintrust.dev/btql",
+        f"{base_url}/btql",
         headers=headers,
         json={"query": full_query, "fmt": "json"},
     )

--- a/skills/using-braintrust/scripts/run_eval.py
+++ b/skills/using-braintrust/scripts/run_eval.py
@@ -60,6 +60,11 @@ def main():
     import braintrust
     from autoevals import Factuality, Score
 
+    # Support custom data planes via BRAINTRUST_APP_URL
+    app_url = os.environ.get("BRAINTRUST_APP_URL")
+    if app_url:
+        braintrust.login(app_url=app_url)
+
     def exact_match_scorer(input, output, expected=None, **kwargs):
         """Scorer that checks for exact match with expected."""
         if expected is None:


### PR DESCRIPTION
## Summary

Organizations using dedicated Braintrust data planes can now set `BRAINTRUST_APP_URL` to point to their custom endpoint. This enables the skill to work in enterprise environments with separate data planes.

## Changes

- `query_logs.py`: Use configurable base URL instead of hardcoded endpoint
- `log_data.py`: Call `braintrust.login()` with `app_url` when set
- `run_eval.py`: Same SDK initialization fix
- `SKILL.md`: Document `BRAINTRUST_APP_URL` in Setup section

## Backward Compatibility

If `BRAINTRUST_APP_URL` is not set, all scripts continue to use the default `api.braintrust.dev` endpoint. No changes required for existing users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)