### PR TITLE
fix: atomic cache writes to prevent corruption under concurrent sessions

### DIFF
--- a/plugins/trace-claude-code/hooks/common.sh
+++ b/plugins/trace-claude-code/hooks/common.sh
@@ -57,9 +57,10 @@ set_cache_value() {
     local key="$1"
     local value="$2"
     local cache
-    cache=$([ -f "$CACHE_FILE" ] && cat "$CACHE_FILE" || echo '{}')
-    cache=$(echo "$cache" | jq --arg k "$key" --arg v "$value" '.[$k] = $v')
-    echo "$cache" > "$CACHE_FILE"
+    cache=$([ -f "$CACHE_FILE" ] && cat "$CACHE_FILE" 2>/dev/null || echo '{}')
+    cache=$(echo "$cache" | jq --arg k "$key" --arg v "$value" '.[$k] = $v' 2>/dev/null) || return 0
+    local tmp="$CACHE_FILE.tmp.$$"
+    echo "$cache" > "$tmp" && mv "$tmp" "$CACHE_FILE"
 }
 
 # Resolve API URL via login endpoint (with caching)


### PR DESCRIPTION
## Summary

`set_cache_value()` in `common.sh` does a non-atomic read-modify-write on the shared cache file. When multiple `claude -p` processes run concurrently, a partial write from one process is visible to another's read, corrupting the JSON and crashing the hook via `set -e`.

## Changes

- Write to a temp file (`$CACHE_FILE.tmp.$$`), then `mv` (atomic on POSIX)
- Suppress `jq` parse errors with `2>/dev/null || return 0` so a corrupted read doesn't crash the hook
- Suppress `cat` stderr for missing file

## Before

```bash
echo "$cache" > "$CACHE_FILE"  # non-atomic: truncate + write
```

## After

```bash
local tmp="$CACHE_FILE.tmp.$$"
echo "$cache" > "$tmp" && mv "$tmp" "$CACHE_FILE"  # atomic rename
```

Fixes #19