### PR TITLE
Emit canonical Claude cache metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,15 @@ claude --settings '{"env":{"CC_PARENT_SPAN_ID":"parent-span-id","CC_ROOT_SPAN_ID
 The plugin derives token usage from the conversation transcript that Claude Code
 writes. For every model request that appears in the transcript — the main
 conversation and sub-agents alike — the traced token counts match Claude Code's
-own `/usage` exactly (input, output, cache read, and cache write).
+own `/usage` exactly and are emitted with Braintrust's canonical metric names.
+
+For Anthropic usage, `prompt_tokens` is inclusive: Claude Code's
+`input_tokens` plus cache-read tokens plus cache-write tokens. Cache reads are
+also emitted as `prompt_cached_tokens`. Cache writes are emitted as
+`prompt_cache_creation_5m_tokens` / `prompt_cache_creation_1h_tokens` when
+Claude Code includes the Anthropic TTL breakdown, or as
+`prompt_cache_creation_tokens` when only the legacy aggregate is present. This
+is the shape Braintrust's backend uses to compute cost.
 
 There is one known and unavoidable exception: **Claude Code's internal background
 model calls** (most notably the automatic **session-title generation**, and

--- a/plugins/trace-claude-code/hooks/common.sh
+++ b/plugins/trace-claude-code/hooks/common.sh
@@ -991,6 +991,9 @@ emit_llm_spans_from_transcript() {
               input_tokens:          ([ .[].message.usage.input_tokens // 0 ]                | max),
               output_tokens:         ([ .[].message.usage.output_tokens // 0 ]               | max),
               cache_creation_tokens: ([ .[].message.usage.cache_creation_input_tokens // 0 ] | max),
+              cache_creation_5m_tokens: ([ .[].message.usage.cache_creation.ephemeral_5m_input_tokens // 0 ] | max),
+              cache_creation_1h_tokens: ([ .[].message.usage.cache_creation.ephemeral_1h_input_tokens // 0 ] | max),
+              cache_creation_has_split: any(.[]; (((.message.usage.cache_creation.ephemeral_5m_input_tokens // 0) + (.message.usage.cache_creation.ephemeral_1h_input_tokens // 0)) > 0)),
               cache_read_tokens:     ([ .[].message.usage.cache_read_input_tokens // 0 ]     | max),
               text: ( [ .[].message.content
                         | if type=="array" then [ .[]|select(.type=="text")|.text ]|join("\n")
@@ -1043,6 +1046,9 @@ emit_llm_spans_from_transcript() {
                   input_tokens: $call.input_tokens,
                   output_tokens: $call.output_tokens,
                   cache_creation_tokens: $call.cache_creation_tokens,
+                  cache_creation_5m_tokens: $call.cache_creation_5m_tokens,
+                  cache_creation_1h_tokens: $call.cache_creation_1h_tokens,
+                  cache_creation_has_split: $call.cache_creation_has_split,
                   cache_read_tokens: $call.cache_read_tokens,
                   input: .history,
                   output: $assistant_msg
@@ -1103,14 +1109,43 @@ emit_llm_spans_from_transcript() {
                     created: (.ts // (now|todate)),
                     input: .input,
                     output: .output,
-                    metrics: {
+                    metrics: ({
                         start: $epoch, end: $epoch,
-                        prompt_tokens: .input_tokens,
+                        prompt_tokens: (
+                            .input_tokens
+                            + .cache_read_tokens
+                            + (
+                                if .cache_creation_has_split then
+                                    (.cache_creation_5m_tokens + .cache_creation_1h_tokens)
+                                else
+                                    .cache_creation_tokens
+                                end
+                            )
+                        ),
                         completion_tokens: .output_tokens,
-                        tokens: (.input_tokens + .output_tokens),
-                        cache_creation_input_tokens: .cache_creation_tokens,
-                        cache_read_input_tokens: .cache_read_tokens
-                    },
+                        tokens: (
+                            .input_tokens
+                            + .cache_read_tokens
+                            + (
+                                if .cache_creation_has_split then
+                                    (.cache_creation_5m_tokens + .cache_creation_1h_tokens)
+                                else
+                                    .cache_creation_tokens
+                                end
+                            )
+                            + .output_tokens
+                        ),
+                        prompt_cached_tokens: .cache_read_tokens
+                    } + (
+                        if .cache_creation_has_split then
+                            {
+                                prompt_cache_creation_5m_tokens: .cache_creation_5m_tokens,
+                                prompt_cache_creation_1h_tokens: .cache_creation_1h_tokens
+                            }
+                        else
+                            {prompt_cache_creation_tokens: .cache_creation_tokens}
+                        end
+                    )),
                     metadata: { model: .model },
                     span_attributes: { name: .model, type: "llm" }
                 }')

--- a/plugins/trace-claude-code/hooks/stop_hook.sh
+++ b/plugins/trace-claude-code/hooks/stop_hook.sh
@@ -102,6 +102,9 @@ CURRENT_MODEL=""
 CURRENT_PROMPT_TOKENS=0
 CURRENT_COMPLETION_TOKENS=0
 CURRENT_CACHE_CREATION_TOKENS=0
+CURRENT_CACHE_CREATION_5M_TOKENS=0
+CURRENT_CACHE_CREATION_1H_TOKENS=0
+CURRENT_CACHE_CREATION_MISSING_SPLIT=false
 CURRENT_CACHE_READ_TOKENS=0
 CURRENT_START_TIMESTAMP=""  # ISO timestamp when this LLM call started
 CURRENT_END_TIMESTAMP=""    # ISO timestamp when this LLM call ended
@@ -164,12 +167,28 @@ create_llm_span() {
     local input_history="$8"  # JSON array of conversation history
     local cache_creation_tokens="${9:-0}"
     local cache_read_tokens="${10:-0}"
+    local cache_creation_5m_tokens="${11:-0}"
+    local cache_creation_1h_tokens="${12:-0}"
+    local cache_creation_missing_split="${13:-false}"
 
     # Need either text or tool_calls
     [ -z "$output_text" ] && [ "$tool_calls_json" = "[]" ] && return
 
     local span_id=$(generate_uuid)
-    local total_tokens=$((prompt_tokens + completion_tokens))
+    local use_cache_creation_split=false
+    if [ "$cache_creation_missing_split" != "true" ]; then
+        if [ "$cache_creation_5m_tokens" -gt 0 ] 2>/dev/null \
+            || [ "$cache_creation_1h_tokens" -gt 0 ] 2>/dev/null; then
+            use_cache_creation_split=true
+        fi
+    fi
+
+    local effective_cache_creation_tokens="$cache_creation_tokens"
+    if [ "$use_cache_creation_split" = "true" ]; then
+        effective_cache_creation_tokens=$((cache_creation_5m_tokens + cache_creation_1h_tokens))
+    fi
+    local bt_prompt_tokens=$((prompt_tokens + cache_read_tokens + effective_cache_creation_tokens))
+    local total_tokens=$((bt_prompt_tokens + completion_tokens))
     local start_time=$(_iso_to_epoch "$start_ts")
     local end_time=$(_iso_to_epoch "$end_ts")
 
@@ -198,10 +217,14 @@ create_llm_span() {
         --argjson output "$output_json" \
         --arg model "${model:-claude}" \
         --argjson prompt_tokens "$prompt_tokens" \
+        --argjson bt_prompt_tokens "$bt_prompt_tokens" \
         --argjson completion_tokens "$completion_tokens" \
         --argjson tokens "$total_tokens" \
         --argjson cache_creation_tokens "$cache_creation_tokens" \
         --argjson cache_read_tokens "$cache_read_tokens" \
+        --argjson cache_creation_5m_tokens "$cache_creation_5m_tokens" \
+        --argjson cache_creation_1h_tokens "$cache_creation_1h_tokens" \
+        --argjson use_cache_creation_split "$use_cache_creation_split" \
         --argjson start_time "$start_time" \
         --argjson end_time "$end_time" \
         '{
@@ -212,15 +235,23 @@ create_llm_span() {
             created: $created,
             input: $input,
             output: $output,
-            metrics: {
+            metrics: ({
                 start: $start_time,
                 end: $end_time,
-                prompt_tokens: $prompt_tokens,
+                prompt_tokens: $bt_prompt_tokens,
                 completion_tokens: $completion_tokens,
                 tokens: $tokens,
-                cache_creation_input_tokens: $cache_creation_tokens,
-                cache_read_input_tokens: $cache_read_tokens
-            },
+                prompt_cached_tokens: $cache_read_tokens
+            } + (
+                if $use_cache_creation_split then
+                    {
+                        prompt_cache_creation_5m_tokens: $cache_creation_5m_tokens,
+                        prompt_cache_creation_1h_tokens: $cache_creation_1h_tokens
+                    }
+                else
+                    {prompt_cache_creation_tokens: $cache_creation_tokens}
+                end
+            )),
             metadata: {
                 model: $model
             },
@@ -258,8 +289,10 @@ flush_pending_llm() {
     if [ "$CURRENT_PROMPT_TOKENS" -gt 0 ] 2>/dev/null \
         || [ "$CURRENT_COMPLETION_TOKENS" -gt 0 ] 2>/dev/null \
         || [ "$CURRENT_CACHE_CREATION_TOKENS" -gt 0 ] 2>/dev/null \
+        || [ "$CURRENT_CACHE_CREATION_5M_TOKENS" -gt 0 ] 2>/dev/null \
+        || [ "$CURRENT_CACHE_CREATION_1H_TOKENS" -gt 0 ] 2>/dev/null \
         || [ "$CURRENT_CACHE_READ_TOKENS" -gt 0 ] 2>/dev/null; then
-        create_llm_span "$CURRENT_OUTPUT_TEXT" "$CURRENT_MODEL" "$CURRENT_PROMPT_TOKENS" "$CURRENT_COMPLETION_TOKENS" "$CURRENT_START_TIMESTAMP" "$CURRENT_END_TIMESTAMP" "$CURRENT_TOOL_CALLS" "$CONVERSATION_HISTORY" "$CURRENT_CACHE_CREATION_TOKENS" "$CURRENT_CACHE_READ_TOKENS"
+        create_llm_span "$CURRENT_OUTPUT_TEXT" "$CURRENT_MODEL" "$CURRENT_PROMPT_TOKENS" "$CURRENT_COMPLETION_TOKENS" "$CURRENT_START_TIMESTAMP" "$CURRENT_END_TIMESTAMP" "$CURRENT_TOOL_CALLS" "$CONVERSATION_HISTORY" "$CURRENT_CACHE_CREATION_TOKENS" "$CURRENT_CACHE_READ_TOKENS" "$CURRENT_CACHE_CREATION_5M_TOKENS" "$CURRENT_CACHE_CREATION_1H_TOKENS" "$CURRENT_CACHE_CREATION_MISSING_SPLIT"
     fi
 
     # Always thread the assistant turn into history, whether or not a span
@@ -302,6 +335,9 @@ while IFS= read -r line; do
             CURRENT_PROMPT_TOKENS=0
             CURRENT_COMPLETION_TOKENS=0
             CURRENT_CACHE_CREATION_TOKENS=0
+            CURRENT_CACHE_CREATION_5M_TOKENS=0
+            CURRENT_CACHE_CREATION_1H_TOKENS=0
+            CURRENT_CACHE_CREATION_MISSING_SPLIT=false
             CURRENT_CACHE_READ_TOKENS=0
             CURRENT_START_TIMESTAMP=""  # Will be set from first assistant message
             CURRENT_END_TIMESTAMP=""
@@ -319,6 +355,9 @@ while IFS= read -r line; do
             CURRENT_PROMPT_TOKENS=0
             CURRENT_COMPLETION_TOKENS=0
             CURRENT_CACHE_CREATION_TOKENS=0
+            CURRENT_CACHE_CREATION_5M_TOKENS=0
+            CURRENT_CACHE_CREATION_1H_TOKENS=0
+            CURRENT_CACHE_CREATION_MISSING_SPLIT=false
             CURRENT_CACHE_READ_TOKENS=0
             CURRENT_START_TIMESTAMP="$MSG_TIMESTAMP"
             CURRENT_END_TIMESTAMP=""
@@ -392,10 +431,16 @@ while IFS= read -r line; do
             OUTPUT_TOKENS=$(echo "$USAGE" | jq -r '.output_tokens // 0' 2>/dev/null)
             CACHE_CREATION=$(echo "$USAGE" | jq -r '.cache_creation_input_tokens // 0' 2>/dev/null)
             CACHE_READ=$(echo "$USAGE" | jq -r '.cache_read_input_tokens // 0' 2>/dev/null)
+            CACHE_CREATION_5M=$(echo "$USAGE" | jq -r '.cache_creation.ephemeral_5m_input_tokens // 0' 2>/dev/null)
+            CACHE_CREATION_1H=$(echo "$USAGE" | jq -r '.cache_creation.ephemeral_1h_input_tokens // 0' 2>/dev/null)
+            HAS_CACHE_CREATION_SPLIT=$(echo "$USAGE" | jq -r 'if ((.cache_creation? // null) | type) == "object" then "true" else "false" end' 2>/dev/null)
             [ "$INPUT_TOKENS" = "null" ] && INPUT_TOKENS=0
             [ "$OUTPUT_TOKENS" = "null" ] && OUTPUT_TOKENS=0
             [ "$CACHE_CREATION" = "null" ] && CACHE_CREATION=0
             [ "$CACHE_READ" = "null" ] && CACHE_READ=0
+            [ "$CACHE_CREATION_5M" = "null" ] && CACHE_CREATION_5M=0
+            [ "$CACHE_CREATION_1H" = "null" ] && CACHE_CREATION_1H=0
+            [ "$HAS_CACHE_CREATION_SPLIT" = "null" ] && HAS_CACHE_CREATION_SPLIT=false
 
             # Determine whether input/cache for this requestId were already
             # counted, and fetch the prior max output for delta accounting.
@@ -420,6 +465,11 @@ while IFS= read -r line; do
                 [ "$INPUT_TOKENS" -gt 0 ] 2>/dev/null && CURRENT_PROMPT_TOKENS=$((CURRENT_PROMPT_TOKENS + INPUT_TOKENS))
                 [ "$CACHE_CREATION" -gt 0 ] 2>/dev/null && CURRENT_CACHE_CREATION_TOKENS=$((CURRENT_CACHE_CREATION_TOKENS + CACHE_CREATION))
                 [ "$CACHE_READ" -gt 0 ] 2>/dev/null && CURRENT_CACHE_READ_TOKENS=$((CURRENT_CACHE_READ_TOKENS + CACHE_READ))
+                [ "$CACHE_CREATION_5M" -gt 0 ] 2>/dev/null && CURRENT_CACHE_CREATION_5M_TOKENS=$((CURRENT_CACHE_CREATION_5M_TOKENS + CACHE_CREATION_5M))
+                [ "$CACHE_CREATION_1H" -gt 0 ] 2>/dev/null && CURRENT_CACHE_CREATION_1H_TOKENS=$((CURRENT_CACHE_CREATION_1H_TOKENS + CACHE_CREATION_1H))
+                if [ "$CACHE_CREATION" -gt 0 ] 2>/dev/null && [ "$HAS_CACHE_CREATION_SPLIT" != "true" ]; then
+                    CURRENT_CACHE_CREATION_MISSING_SPLIT=true
+                fi
             fi
 
             # Output: add only the increase over this requestId's prior max,

--- a/plugins/trace-claude-code/test/test_common.sh
+++ b/plugins/trace-claude-code/test/test_common.sh
@@ -332,10 +332,14 @@ t_emit_dedupes_by_request_id() {
     assert_eq "$(jq -s '[.[]|select(.span_attributes.type=="tool")]|length' "$out")" "1" "one tool span"
 
     # Output is the MAX per request: A=30 (not 5), B=20 -> 50.
-    # cache_read 2000 + 2500 = 4500, prompt 5 + 2 = 7 (constant per request).
-    assert_eq "$(jq -s '[.[]|select(.span_attributes.type=="llm")|.metrics.completion_tokens]|add' "$out")"        "50"   "completion uses max per request"
-    assert_eq "$(jq -s '[.[]|select(.span_attributes.type=="llm")|.metrics.prompt_tokens]|add' "$out")"           "7"    "prompt deduped"
-    assert_eq "$(jq -s '[.[]|select(.span_attributes.type=="llm")|.metrics.cache_read_input_tokens]|add' "$out")" "4500" "cache_read deduped"
+    # Braintrust prompt_tokens are inclusive for Anthropic:
+    # input 7 + cache_read 4500 + cache_creation 103 = 4610.
+    assert_eq "$(jq -s '[.[]|select(.span_attributes.type=="llm")|.metrics.completion_tokens]|add' "$out")"             "50"   "completion uses max per request"
+    assert_eq "$(jq -s '[.[]|select(.span_attributes.type=="llm")|.metrics.prompt_tokens]|add' "$out")"                "4610" "prompt includes input and cache tokens"
+    assert_eq "$(jq -s '[.[]|select(.span_attributes.type=="llm")|.metrics.tokens]|add' "$out")"                       "4660" "total tokens includes inclusive prompt and completion"
+    assert_eq "$(jq -s '[.[]|select(.span_attributes.type=="llm")|.metrics.prompt_cached_tokens]|add' "$out")"         "4500" "cache_read deduped"
+    assert_eq "$(jq -s '[.[]|select(.span_attributes.type=="llm")|.metrics.prompt_cache_creation_tokens]|add' "$out")" "103"  "cache_creation deduped"
+    assert_eq "$(jq -s '[.[]|select(.span_attributes.type=="llm" and (.metrics | (has("cache_read_input_tokens") or has("cache_creation_input_tokens"))))]|length' "$out")" "0" "raw Anthropic cache metrics are not emitted"
 
     # All spans parented under PARENT.
     assert_eq "$(jq -s 'all(.[]; .span_parents[0] == "PARENT")' "$out")" "true" "all parented under PARENT"

--- a/plugins/trace-claude-code/test/test_fixture_replay.sh
+++ b/plugins/trace-claude-code/test/test_fixture_replay.sh
@@ -249,17 +249,21 @@ t_token_dedupe_totals() {
     local llms
     llms=$(all_spans | jq '[.[] | select(.span_attributes.type == "llm")]')
 
-    local total_prompt total_completion total_cache_creation total_cache_read
+    local total_prompt total_completion total_cache_creation total_cache_read total_tokens raw_metric_count
     total_prompt=$(echo "$llms" | jq '[.[].metrics.prompt_tokens // 0] | add')
     total_completion=$(echo "$llms" | jq '[.[].metrics.completion_tokens // 0] | add')
-    total_cache_creation=$(echo "$llms" | jq '[.[].metrics.cache_creation_input_tokens // 0] | add')
-    total_cache_read=$(echo "$llms" | jq '[.[].metrics.cache_read_input_tokens // 0] | add')
+    total_cache_creation=$(echo "$llms" | jq '[.[].metrics.prompt_cache_creation_tokens // 0, .[].metrics.prompt_cache_creation_5m_tokens // 0, .[].metrics.prompt_cache_creation_1h_tokens // 0] | add')
+    total_cache_read=$(echo "$llms" | jq '[.[].metrics.prompt_cached_tokens // 0] | add')
+    total_tokens=$(echo "$llms" | jq '[.[].metrics.tokens // 0] | add')
+    raw_metric_count=$(echo "$llms" | jq '[.[] | select(.metrics | (has("cache_creation_input_tokens") or has("cache_read_input_tokens")))] | length')
 
     # Expected = sum of usage over the 7 unique requestIds in the transcript.
-    assert_eq "$total_prompt"         "368"    "prompt_tokens should dedupe by requestId"
+    assert_eq "$total_prompt"         "187216" "prompt_tokens should include input and cache tokens deduped by requestId"
     assert_eq "$total_completion"     "1867"   "completion_tokens should dedupe by requestId"
-    assert_eq "$total_cache_creation" "21064"  "cache_creation_input_tokens should dedupe by requestId"
-    assert_eq "$total_cache_read"     "165784" "cache_read_input_tokens should dedupe by requestId"
+    assert_eq "$total_cache_creation" "21064"  "prompt cache creation tokens should dedupe by requestId"
+    assert_eq "$total_cache_read"     "165784" "prompt_cached_tokens should dedupe by requestId"
+    assert_eq "$total_tokens"         "189083" "tokens should include inclusive prompt and completion"
+    assert_eq "$raw_metric_count"     "0"      "raw Anthropic cache metrics should not be emitted"
 
     # Turn merge spans must NOT carry token metrics anymore.
     local merge_tokens
@@ -288,7 +292,7 @@ describe "subagent-compact: sub-agent LLM spans"
 # The test then asserts the replayed spans match that derived expectation.
 SUBAGENT_FIXTURE="$SCRIPT_DIR/fixtures/sessions/subagent-compact"
 
-# Compute expected {spans,output,cache_read,cache_creation} from the fixture's
+# Compute expected {spans,input,output,cache_read,cache_creation} from the fixture's
 # agent-*.jsonl transcripts. Prints a compact JSON object.
 _expected_subagent_totals() {
     jq -s '
@@ -296,12 +300,14 @@ _expected_subagent_totals() {
           | select(.type=="assistant")
           | select(.message.usage != null)
           | { rid:(.requestId // .message.id),
+              in:(.message.usage.input_tokens // 0),
               out:(.message.usage.output_tokens // 0),
               cr:(.message.usage.cache_read_input_tokens // 0),
               cc:(.message.usage.cache_creation_input_tokens // 0) }
         ]
         | group_by(.rid)
         | { spans: length,
+            input:          (map(.[0].in)       | add),
             output:         (map([.[].out]|max) | add),
             cache_read:     (map(.[0].cr)       | add),
             cache_creation: (map(.[0].cc)       | add) }
@@ -320,11 +326,14 @@ t_subagent_llm_spans() {
 
     local expected
     expected=$(_expected_subagent_totals)
-    local exp_spans exp_out exp_cr exp_cc
+    local exp_spans exp_in exp_out exp_cr exp_cc exp_prompt exp_tokens
     exp_spans=$(echo "$expected" | jq '.spans')
+    exp_in=$(echo "$expected" | jq '.input')
     exp_out=$(echo "$expected" | jq '.output')
     exp_cr=$(echo "$expected" | jq '.cache_read')
     exp_cc=$(echo "$expected" | jq '.cache_creation')
+    exp_prompt=$((exp_in + exp_cr + exp_cc))
+    exp_tokens=$((exp_prompt + exp_out))
 
     # Collect the sub-agent LLM spans: llm spans whose parent is an Agent
     # tool span (model-agnostic, since the sub-agent model may differ between
@@ -336,9 +345,12 @@ t_subagent_llm_spans() {
 
     # Span count and deduped token totals match what the transcripts imply.
     assert_eq "$(echo "$subagent_spans" | jq 'length')" "$exp_spans" "sub-agent span count matches transcripts"
-    assert_eq "$(echo "$subagent_spans" | jq '[.[].metrics.completion_tokens]|add')"           "$exp_out" "sub-agent completion (max per request)"
-    assert_eq "$(echo "$subagent_spans" | jq '[.[].metrics.cache_read_input_tokens]|add')"     "$exp_cr"  "sub-agent cache_read total"
-    assert_eq "$(echo "$subagent_spans" | jq '[.[].metrics.cache_creation_input_tokens]|add')" "$exp_cc"  "sub-agent cache_creation total"
+    assert_eq "$(echo "$subagent_spans" | jq '[.[].metrics.completion_tokens]|add')" "$exp_out" "sub-agent completion (max per request)"
+    assert_eq "$(echo "$subagent_spans" | jq '[.[].metrics.prompt_tokens]|add')"     "$exp_prompt" "sub-agent prompt includes input and cache tokens"
+    assert_eq "$(echo "$subagent_spans" | jq '[.[].metrics.tokens]|add')"            "$exp_tokens" "sub-agent total tokens"
+    assert_eq "$(echo "$subagent_spans" | jq '[.[].metrics.prompt_cached_tokens]|add')" "$exp_cr"  "sub-agent cache_read total"
+    assert_eq "$(echo "$subagent_spans" | jq '[.[].metrics.prompt_cache_creation_tokens // 0, .[].metrics.prompt_cache_creation_5m_tokens // 0, .[].metrics.prompt_cache_creation_1h_tokens // 0] | add')" "$exp_cc" "sub-agent cache_creation total"
+    assert_eq "$(echo "$subagent_spans" | jq '[.[] | select(.metrics | (has("cache_creation_input_tokens") or has("cache_read_input_tokens")))] | length')" "0" "sub-agent raw Anthropic cache metrics absent"
 
     # Sanity: at least one sub-agent span was actually produced.
     if [ "$exp_spans" -gt 0 ]; then

--- a/plugins/trace-claude-code/test/test_post_tool_use.sh
+++ b/plugins/trace-claude-code/test/test_post_tool_use.sh
@@ -234,9 +234,14 @@ t_agent_emits_subagent_llm_spans() {
         '[.[]|select(.span_attributes.type=="tool" and .span_parents[0]==$p)][0]')
     assert_eq "$(echo "$subagent_tool" | jq -r '.span_attributes.name')" "Terminal: ls -la" "sub-agent tool span named after the Bash command"
 
-    # Token totals match the deduped transcript (completion 40+20, cache_read 1000+1500).
-    assert_eq "$(all_spans | jq '[.[]|select(.span_attributes.type=="llm")|.metrics.completion_tokens]|add')" "60"   "completion summed"
-    assert_eq "$(all_spans | jq '[.[]|select(.span_attributes.type=="llm")|.metrics.cache_read_input_tokens]|add')" "2500" "cache_read summed"
+    # Token totals match the deduped transcript. Braintrust prompt_tokens are
+    # inclusive for Anthropic: input 8 + cache_read 2500 + cache_creation 15 = 2523.
+    assert_eq "$(all_spans | jq '[.[]|select(.span_attributes.type=="llm")|.metrics.completion_tokens]|add')"             "60"   "completion summed"
+    assert_eq "$(all_spans | jq '[.[]|select(.span_attributes.type=="llm")|.metrics.prompt_tokens]|add')"                "2523" "prompt includes input and cache tokens"
+    assert_eq "$(all_spans | jq '[.[]|select(.span_attributes.type=="llm")|.metrics.tokens]|add')"                       "2583" "total tokens includes inclusive prompt and completion"
+    assert_eq "$(all_spans | jq '[.[]|select(.span_attributes.type=="llm")|.metrics.prompt_cached_tokens]|add')"         "2500" "cache_read summed"
+    assert_eq "$(all_spans | jq '[.[]|select(.span_attributes.type=="llm")|.metrics.prompt_cache_creation_tokens]|add')" "15"   "cache_creation summed"
+    assert_eq "$(all_spans | jq '[.[]|select(.span_attributes.type=="llm" and (.metrics | (has("cache_read_input_tokens") or has("cache_creation_input_tokens"))))]|length')" "0" "raw Anthropic cache metrics are not emitted"
 
     # The LLM spans are tagged with the sub-agent's model.
     assert_eq "$(all_spans | jq '[.[]|select(.span_attributes.type=="llm")]|all(.span_attributes.name=="claude-haiku-4-5")')" "true" "sub-agent model tagged"

--- a/plugins/trace-claude-code/test/test_stop_hook.sh
+++ b/plugins/trace-claude-code/test/test_stop_hook.sh
@@ -141,7 +141,10 @@ t_stop_merge_has_end_time_no_tokens() {
     assert_eq "$(echo "$span" | jq -r '.metrics.prompt_tokens // "absent"')"     "absent" "no prompt_tokens on Turn merge"
     assert_eq "$(echo "$span" | jq -r '.metrics.completion_tokens // "absent"')" "absent" "no completion_tokens on Turn merge"
     assert_eq "$(echo "$span" | jq -r '.metrics.tokens // "absent"')"            "absent" "no tokens on Turn merge"
-    assert_eq "$(echo "$span" | jq -r '.metrics.cache_read_input_tokens // "absent"')" "absent" "no cache_read on Turn merge"
+    assert_eq "$(echo "$span" | jq -r '.metrics.prompt_cached_tokens // "absent"')" "absent" "no cache_read on Turn merge"
+    assert_eq "$(echo "$span" | jq -r '.metrics.prompt_cache_creation_tokens // "absent"')" "absent" "no cache_creation on Turn merge"
+    assert_eq "$(echo "$span" | jq -r '.metrics.prompt_cache_creation_5m_tokens // "absent"')" "absent" "no cache_creation_5m on Turn merge"
+    assert_eq "$(echo "$span" | jq -r '.metrics.prompt_cache_creation_1h_tokens // "absent"')" "absent" "no cache_creation_1h on Turn merge"
 }
 
 # ---------------------------------------------------------------------------
@@ -301,8 +304,10 @@ t_stop_same_request_not_split_into_zero_token_spans() {
         .[] | select(
             (.metrics.prompt_tokens // 0) == 0
             and (.metrics.completion_tokens // 0) == 0
-            and (.metrics.cache_creation_input_tokens // 0) == 0
-            and (.metrics.cache_read_input_tokens // 0) == 0
+            and (.metrics.prompt_cache_creation_tokens // 0) == 0
+            and (.metrics.prompt_cache_creation_5m_tokens // 0) == 0
+            and (.metrics.prompt_cache_creation_1h_tokens // 0) == 0
+            and (.metrics.prompt_cached_tokens // 0) == 0
         )
     ] | length')
     assert_eq "$zero_token_spans" "0" "no LLM span should carry all-zero token metrics"
@@ -320,6 +325,46 @@ t_stop_same_request_not_split_into_zero_token_spans() {
     assert_eq "$total_completion" "35" "total completion_tokens preserved across spans"
 }
 
+t_stop_emits_split_cache_metrics() {
+    _with_turn_started "stop-cache-split-1"
+
+    local transcript="$TEST_TMP/transcript.jsonl"
+    jq -nc '{
+        type: "assistant",
+        requestId: "req_cache",
+        timestamp: "2024-01-01T00:00:00.000Z",
+        message: {
+            model: "claude-test",
+            content: [{type: "text", text: "cached answer"}],
+            usage: {
+                input_tokens: 7,
+                cache_creation_input_tokens: 30,
+                cache_read_input_tokens: 100,
+                cache_creation: {
+                    ephemeral_5m_input_tokens: 10,
+                    ephemeral_1h_input_tokens: 20
+                },
+                output_tokens: 5
+            }
+        }
+    }' > "$transcript"
+
+    run_hook stop_hook.sh "$(fixture_stop "stop-cache-split-1" "$transcript" "cached answer")"
+    assert_success "$HOOK_STATUS"
+
+    local llm
+    llm=$(all_spans | jq '[.[] | select(.span_attributes.type == "llm")][0]')
+
+    assert_eq "$(echo "$llm" | jq -r '.metrics.prompt_tokens')" "137" "prompt includes input, cache read, and cache write"
+    assert_eq "$(echo "$llm" | jq -r '.metrics.tokens')" "142" "tokens includes inclusive prompt and completion"
+    assert_eq "$(echo "$llm" | jq -r '.metrics.prompt_cached_tokens')" "100" "cache read uses canonical metric"
+    assert_eq "$(echo "$llm" | jq -r '.metrics.prompt_cache_creation_5m_tokens')" "10" "5m cache write uses canonical metric"
+    assert_eq "$(echo "$llm" | jq -r '.metrics.prompt_cache_creation_1h_tokens')" "20" "1h cache write uses canonical metric"
+    assert_eq "$(echo "$llm" | jq -r '.metrics.prompt_cache_creation_tokens // "absent"')" "absent" "aggregate cache write omitted when split is present"
+    assert_eq "$(echo "$llm" | jq -r '.metrics.cache_creation_input_tokens // "absent"')" "absent" "raw cache creation omitted"
+    assert_eq "$(echo "$llm" | jq -r '.metrics.cache_read_input_tokens // "absent"')" "absent" "raw cache read omitted"
+}
+
 it "writes last_assistant_message into the Turn span output"  t_stop_sets_turn_output
 it "leaves output empty when last_assistant_message missing"  t_stop_output_empty_when_message_missing
 it "targets the existing Turn span id via merge"              t_stop_turn_update_has_correct_id
@@ -327,3 +372,4 @@ it "sets _is_merge=true on the update"                        t_stop_merge_flag_
 it "merge carries end time but no token metrics"              t_stop_merge_has_end_time_no_tokens
 it "does not double-count streaming output across 3+ lines"   t_stop_streaming_output_not_double_counted
 it "emits one LLM span per requestId across tool_result splits" t_stop_same_request_not_split_into_zero_token_spans
+it "emits canonical split cache metrics"                      t_stop_emits_split_cache_metrics


### PR DESCRIPTION
## Summary
- emit Braintrust canonical cache metrics from Claude Code usage instead of raw Anthropic cache metric names
- make Anthropic prompt and total token counts inclusive of cache read/write tokens
- preserve aggregate-only fallback and prefer 5m/1h split cache write metrics when Claude Code exposes the TTL breakdown
- document the canonical metric shape and update fixture/unit assertions

## Validation
- bash plugins/trace-claude-code/test/run_tests.sh test_common test_post_tool_use test_fixture_replay test_stop_hook
- make test