### PR TITLE
Track implicit skill loads

### DIFF
--- a/plugins/trace-claude-code/hooks/post_tool_use.sh
+++ b/plugins/trace-claude-code/hooks/post_tool_use.sh
@@ -57,7 +57,22 @@ TIMESTAMP=$(get_timestamp)
 TOOL_TIME=$(date +%s)
 
 # Determine span name based on tool
+METADATA_TOOL_NAME="$TOOL_NAME"
+ORIGINAL_TOOL_NAME=""
+IS_SKILL_TOOL=false
+SKILL_NAME=""
 case "$TOOL_NAME" in
+    Skill)
+        METADATA_TOOL_NAME="skill"
+        ORIGINAL_TOOL_NAME="$TOOL_NAME"
+        IS_SKILL_TOOL=true
+        SKILL_NAME=$(echo "$TOOL_INPUT" | jq -r '.name // .skill // .skill_name // .skillName // empty' 2>/dev/null)
+        if [ -n "$SKILL_NAME" ]; then
+            SPAN_NAME="skill: $SKILL_NAME"
+        else
+            SPAN_NAME="skill"
+        fi
+        ;;
     Read|Write|Edit|MultiEdit)
         FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.file_path // .path // empty' 2>/dev/null)
         if [ -n "$FILE_PATH" ]; then
@@ -89,6 +104,10 @@ EVENT=$(jq -n \
     --argjson input "$TOOL_INPUT" \
     --argjson output "$TOOL_OUTPUT" \
     --arg name "$SPAN_NAME" \
+    --arg metadata_tool "$METADATA_TOOL_NAME" \
+    --arg original_tool "$ORIGINAL_TOOL_NAME" \
+    --arg skill_name "$SKILL_NAME" \
+    --argjson is_skill_tool "$IS_SKILL_TOOL" \
     --argjson start_time "$TOOL_TIME" \
     --argjson end_time "$TOOL_TIME" \
     '{
@@ -103,9 +122,13 @@ EVENT=$(jq -n \
             start: $start_time,
             end: $end_time
         },
-        metadata: {
-            tool_name: $tool
-        },
+        metadata: ({
+            tool_name: $metadata_tool
+        }
+        + (if $original_tool != "" then {original_tool_name: $original_tool} else {} end)
+        + (if $is_skill_tool then {
+            skill_name: (if $skill_name != "" then $skill_name else null end)
+        } else {} end)),
         span_attributes: {
             name: $name,
             type: "tool"

--- a/plugins/trace-claude-code/test/test_post_tool_use.sh
+++ b/plugins/trace-claude-code/test/test_post_tool_use.sh
@@ -90,6 +90,22 @@ t_read_tool_span_name_includes_basename() {
     assert_eq "$name" "Read: file.txt"
 }
 
+t_skill_tool_span_is_normalized() {
+    _with_turn_started "sess-pt-skill"
+
+    run_hook post_tool_use.sh "$(fixture_post_tool_use "sess-pt-skill" "Skill" \
+        "$(jq -nc '{name: "review"}')" \
+        "$(fixture_tool_response_text 'loaded')")"
+
+    local tool_span name
+    tool_span=$(span_by_type "tool")
+    name=$(echo "$tool_span" | jq -r '.span_attributes.name')
+    assert_eq "$name" "skill: review"
+    assert_eq "$(echo "$tool_span" | jq -r '.metadata.tool_name')" "skill"
+    assert_eq "$(echo "$tool_span" | jq -r '.metadata.original_tool_name')" "Skill"
+    assert_eq "$(echo "$tool_span" | jq -r '.metadata.skill_name')" "review"
+}
+
 t_multiple_tools_in_turn() {
     _with_turn_started "sess-pt-multi"
 
@@ -113,6 +129,7 @@ t_multiple_tools_in_turn() {
 it "creates a tool span on PostToolUse"             t_post_tool_creates_tool_span
 it "tool span is a child of the current Turn span"  t_tool_span_is_child_of_turn
 it "Read tool span name includes file basename"     t_read_tool_span_name_includes_basename
+it "Skill tool span is normalized as skill load"    t_skill_tool_span_is_normalized
 it "all tools in a turn produce distinct spans"     t_multiple_tools_in_turn
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- normalize Claude Skill tool calls as observed skill-load tool spans
- attach singular skill metadata including skill name and original tool name
- omit the optional skill_load_trigger field for phase 1, so these loads default to implicit under the spec
- add post-tool hook coverage for the normalized span payload

## Spec
- braintrustdata/braintrust-spec#35

## Validation
- ./run_tests.sh test_post_tool_use