### PR TITLE
Implement explicit skill capture

### DIFF
--- a/plugins/trace-claude-code/hooks/hooks.json
+++ b/plugins/trace-claude-code/hooks/hooks.json
@@ -72,7 +72,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/record_event.sh UserPromptExpansion",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/user_prompt_expansion.sh",
             "async": false
           }
         ]

--- a/plugins/trace-claude-code/hooks/post_tool_use.sh
+++ b/plugins/trace-claude-code/hooks/post_tool_use.sh
@@ -61,12 +61,18 @@ METADATA_TOOL_NAME="$TOOL_NAME"
 ORIGINAL_TOOL_NAME=""
 IS_SKILL_TOOL=false
 SKILL_NAME=""
+SKILL_LOAD_TRIGGER=""
 case "$TOOL_NAME" in
     Skill)
         METADATA_TOOL_NAME="skill"
         ORIGINAL_TOOL_NAME="$TOOL_NAME"
         IS_SKILL_TOOL=true
         SKILL_NAME=$(echo "$TOOL_INPUT" | jq -r '.name // .skill // .skill_name // .skillName // empty' 2>/dev/null)
+        EXPLICIT_SKILL_NAMES=$(get_session_state "$SESSION_ID" "current_turn_explicit_skill_names")
+        if [ -n "$SKILL_NAME" ] && [ -n "$EXPLICIT_SKILL_NAMES" ] && \
+            echo "$EXPLICIT_SKILL_NAMES" | jq -e --arg name "$SKILL_NAME" 'index($name) != null' >/dev/null 2>&1; then
+            SKILL_LOAD_TRIGGER="explicit"
+        fi
         if [ -n "$SKILL_NAME" ]; then
             SPAN_NAME="skill: $SKILL_NAME"
         else
@@ -107,6 +113,7 @@ EVENT=$(jq -n \
     --arg metadata_tool "$METADATA_TOOL_NAME" \
     --arg original_tool "$ORIGINAL_TOOL_NAME" \
     --arg skill_name "$SKILL_NAME" \
+    --arg skill_load_trigger "$SKILL_LOAD_TRIGGER" \
     --argjson is_skill_tool "$IS_SKILL_TOOL" \
     --argjson start_time "$TOOL_TIME" \
     --argjson end_time "$TOOL_TIME" \
@@ -128,7 +135,8 @@ EVENT=$(jq -n \
         + (if $original_tool != "" then {original_tool_name: $original_tool} else {} end)
         + (if $is_skill_tool then {
             skill_name: (if $skill_name != "" then $skill_name else null end)
-        } else {} end)),
+        } else {} end)
+        + (if $skill_load_trigger != "" then {skill_load_trigger: $skill_load_trigger} else {} end)),
         span_attributes: {
             name: $name,
             type: "tool"

--- a/plugins/trace-claude-code/hooks/post_tool_use.sh
+++ b/plugins/trace-claude-code/hooks/post_tool_use.sh
@@ -58,14 +58,11 @@ TOOL_TIME=$(date +%s)
 
 # Determine span name based on tool
 METADATA_TOOL_NAME="$TOOL_NAME"
-ORIGINAL_TOOL_NAME=""
 IS_SKILL_TOOL=false
 SKILL_NAME=""
 SKILL_LOAD_TRIGGER=""
 case "$TOOL_NAME" in
     Skill)
-        METADATA_TOOL_NAME="skill"
-        ORIGINAL_TOOL_NAME="$TOOL_NAME"
         IS_SKILL_TOOL=true
         SKILL_NAME=$(echo "$TOOL_INPUT" | jq -r '.name // .skill // .skill_name // .skillName // empty' 2>/dev/null)
         EXPLICIT_SKILL_NAMES=$(get_session_state "$SESSION_ID" "current_turn_explicit_skill_names")
@@ -111,7 +108,6 @@ EVENT=$(jq -n \
     --argjson output "$TOOL_OUTPUT" \
     --arg name "$SPAN_NAME" \
     --arg metadata_tool "$METADATA_TOOL_NAME" \
-    --arg original_tool "$ORIGINAL_TOOL_NAME" \
     --arg skill_name "$SKILL_NAME" \
     --arg skill_load_trigger "$SKILL_LOAD_TRIGGER" \
     --argjson is_skill_tool "$IS_SKILL_TOOL" \
@@ -132,8 +128,8 @@ EVENT=$(jq -n \
         metadata: ({
             tool_name: $metadata_tool
         }
-        + (if $original_tool != "" then {original_tool_name: $original_tool} else {} end)
         + (if $is_skill_tool then {
+            tool_kind: "skill",
             skill_name: (if $skill_name != "" then $skill_name else null end)
         } else {} end)
         + (if $skill_load_trigger != "" then {skill_load_trigger: $skill_load_trigger} else {} end)),

--- a/plugins/trace-claude-code/hooks/stop_hook.sh
+++ b/plugins/trace-claude-code/hooks/stop_hook.sh
@@ -521,6 +521,7 @@ enqueue_span "$SESSION_ID" "$PROJECT_ID" "$TURN_UPDATE" || true
 # Update state
 set_session_state "$SESSION_ID" "turn_last_line" "$TOTAL_LINES"
 set_session_state "$SESSION_ID" "current_turn_span_id" ""
+set_session_state "$SESSION_ID" "current_turn_explicit_skill_names" "[]"
 
 [ "$LLM_CALLS_CREATED" -gt 0 ] && log "INFO" "Created $LLM_CALLS_CREATED LLM spans for turn"
 log "INFO" "Turn finalized (end=$END_TIME)"

--- a/plugins/trace-claude-code/hooks/user_prompt_expansion.sh
+++ b/plugins/trace-claude-code/hooks/user_prompt_expansion.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+###
+# UserPromptExpansion Hook - Captures explicit Claude slash skill requests.
+###
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+tracing_enabled || exit 0
+check_requirements || exit 0
+
+INPUT=$(cat)
+record_hook_input "UserPromptExpansion" "$INPUT"
+
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+[ -z "$SESSION_ID" ] && exit 0
+
+EXPANSION_TYPE=$(echo "$INPUT" | jq -r '.expansion_type // .type // empty' 2>/dev/null)
+if [ -n "$EXPANSION_TYPE" ] && [ "$EXPANSION_TYPE" != "slash_command" ]; then
+    exit 0
+fi
+
+_normalize_skill_name() {
+    echo "$1" | sed 's#^/##' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//' | sed 's/[),.;:]*$//'
+}
+
+_skill_listing_contains() {
+    local transcript="$1"
+    local name="$2"
+    [ -n "$transcript" ] && [ -f "$transcript" ] || return 1
+    jq -e --arg name "$name" '
+        select(.attachment.type == "skill_listing")
+        | .attachment.names[]?
+        | select(. == $name)
+    ' "$transcript" >/dev/null 2>&1
+}
+
+SKILL_NAME=$(echo "$INPUT" | jq -r '
+    .skill_name
+    // .skillName
+    // .skill.name
+    // .skill
+    // empty
+' 2>/dev/null)
+
+if [ -z "$SKILL_NAME" ]; then
+    COMMAND_NAME=$(echo "$INPUT" | jq -r '.command_name // .command // .slash_command // .name // empty' 2>/dev/null)
+    COMMAND_NAME=$(_normalize_skill_name "$COMMAND_NAME")
+    TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
+    if [ -n "$COMMAND_NAME" ] && _skill_listing_contains "$TRANSCRIPT_PATH" "$COMMAND_NAME"; then
+        SKILL_NAME="$COMMAND_NAME"
+    fi
+fi
+
+SKILL_NAME=$(_normalize_skill_name "$SKILL_NAME")
+[ -z "$SKILL_NAME" ] && exit 0
+
+EXISTING=$(get_session_state "$SESSION_ID" "current_turn_explicit_skill_names")
+[ -z "$EXISTING" ] && EXISTING="[]"
+
+NAMES_JSON=$(jq -nc --argjson existing "$EXISTING" --arg name "$SKILL_NAME" '
+    ($existing + [$name])
+    | reduce .[] as $name ([]; if index($name) then . else . + [$name] end)
+' 2>/dev/null || jq -nc --arg name "$SKILL_NAME" '[$name]')
+
+set_session_state "$SESSION_ID" "current_turn_explicit_skill_names" "$NAMES_JSON"
+
+TURN_SPAN_ID=$(get_session_state "$SESSION_ID" "current_turn_span_id")
+PROJECT_ID=$(get_session_state "$SESSION_ID" "project_id")
+[ -n "$TURN_SPAN_ID" ] && [ -n "$PROJECT_ID" ] || exit 0
+
+ROOT_SPAN_ID=$(get_session_state "$SESSION_ID" "root_span_id")
+
+EVENT=$(jq -n \
+    --arg id "$TURN_SPAN_ID" \
+    --argjson names "$NAMES_JSON" \
+    '{
+        id: $id,
+        _is_merge: true,
+        metadata: {
+            loaded_skill_names: $names,
+            loaded_skills: ($names | map({name: .}))
+        }
+    }')
+
+enqueue_span "$SESSION_ID" "$PROJECT_ID" "$EVENT" || true
+
+log "INFO" "Explicit skill request: $SKILL_NAME (turn=$TURN_SPAN_ID root=$ROOT_SPAN_ID)"
+
+exit 0

--- a/plugins/trace-claude-code/hooks/user_prompt_submit.sh
+++ b/plugins/trace-claude-code/hooks/user_prompt_submit.sh
@@ -105,6 +105,9 @@ TURN_SPAN_ID=$(generate_uuid)
 TIMESTAMP=$(get_timestamp)
 START_TIME=$(date +%s)
 
+EXPLICIT_SKILL_NAMES=$(get_session_state "$SESSION_ID" "current_turn_explicit_skill_names")
+[ -z "$EXPLICIT_SKILL_NAMES" ] && EXPLICIT_SKILL_NAMES="[]"
+
 # Truncate prompt for display (first 100 chars)
 PROMPT_PREVIEW="${PROMPT:0:100}"
 [ ${#PROMPT} -gt 100 ] && PROMPT_PREVIEW="${PROMPT_PREVIEW}..."
@@ -117,6 +120,7 @@ EVENT=$(jq -n \
     --arg session_span_id "$SESSION_SPAN_ID" \
     --arg created "$TIMESTAMP" \
     --arg prompt "$PROMPT" \
+    --argjson explicit_skill_names "$EXPLICIT_SKILL_NAMES" \
     --argjson turn "$TURN_COUNT" \
     --argjson start_time "$START_TIME" \
     '{
@@ -129,6 +133,10 @@ EVENT=$(jq -n \
         metrics: {
             start: $start_time
         },
+        metadata: (if ($explicit_skill_names | length) > 0 then {
+            loaded_skill_names: $explicit_skill_names,
+            loaded_skills: ($explicit_skill_names | map({name: .}))
+        } else {} end),
         span_attributes: {
             name: ("Turn " + ($turn | tostring)),
             type: "task"

--- a/plugins/trace-claude-code/test/test_post_tool_use.sh
+++ b/plugins/trace-claude-code/test/test_post_tool_use.sh
@@ -90,7 +90,7 @@ t_read_tool_span_name_includes_basename() {
     assert_eq "$name" "Read: file.txt"
 }
 
-t_skill_tool_span_is_normalized() {
+t_skill_tool_span_marks_tool_kind() {
     _with_turn_started "sess-pt-skill"
 
     run_hook post_tool_use.sh "$(fixture_post_tool_use "sess-pt-skill" "Skill" \
@@ -101,8 +101,8 @@ t_skill_tool_span_is_normalized() {
     tool_span=$(span_by_type "tool")
     name=$(echo "$tool_span" | jq -r '.span_attributes.name')
     assert_eq "$name" "skill: review"
-    assert_eq "$(echo "$tool_span" | jq -r '.metadata.tool_name')" "skill"
-    assert_eq "$(echo "$tool_span" | jq -r '.metadata.original_tool_name')" "Skill"
+    assert_eq "$(echo "$tool_span" | jq -r '.metadata.tool_name')" "Skill"
+    assert_eq "$(echo "$tool_span" | jq -r '.metadata.tool_kind')" "skill"
     assert_eq "$(echo "$tool_span" | jq -r '.metadata.skill_name')" "review"
 }
 
@@ -129,7 +129,7 @@ t_multiple_tools_in_turn() {
 it "creates a tool span on PostToolUse"             t_post_tool_creates_tool_span
 it "tool span is a child of the current Turn span"  t_tool_span_is_child_of_turn
 it "Read tool span name includes file basename"     t_read_tool_span_name_includes_basename
-it "Skill tool span is normalized as skill load"    t_skill_tool_span_is_normalized
+it "Skill tool span marks tool kind"                t_skill_tool_span_marks_tool_kind
 it "all tools in a turn produce distinct spans"     t_multiple_tools_in_turn
 
 # ---------------------------------------------------------------------------

--- a/plugins/trace-claude-code/test/test_user_prompt_expansion.sh
+++ b/plugins/trace-claude-code/test/test_user_prompt_expansion.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+###
+# End-to-end tests for explicit skill capture from UserPromptExpansion.
+###
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/assert.sh
+source "$SCRIPT_DIR/helpers/assert.sh"
+# shellcheck source=helpers/harness.sh
+source "$SCRIPT_DIR/helpers/harness.sh"
+
+_setup_default_stubs() {
+    stub_response_for "*/v1/project?project_name=*" 200 '{"id":"proj_test"}'
+    stub_response_for "*/v1/project_logs/*/insert"  200 '{"row_ids":["row_1"]}'
+}
+
+_skill_listing_transcript() {
+    local path="$1"
+    jq -nc '{attachment: {type: "skill_listing", names: ["review", "security-review"]}}' > "$path"
+}
+
+_fixture_user_prompt_expansion() {
+    local session_id="$1"
+    local command_name="$2"
+    local transcript_path="$3"
+    jq -nc \
+        --arg s "$session_id" \
+        --arg c "$command_name" \
+        --arg t "$transcript_path" \
+        '{
+            session_id: $s,
+            expansion_type: "slash_command",
+            command_name: $c,
+            transcript_path: $t
+        }'
+}
+
+_with_started_session() {
+    local session_id="$1"
+    _setup_default_stubs
+    run_hook session_start.sh "$(fixture_session_start "$session_id" "/tmp/x")"
+}
+
+_with_turn_started() {
+    local session_id="$1"
+    _with_started_session "$session_id"
+    run_hook user_prompt_submit.sh "$(fixture_user_prompt "$session_id" "do something")"
+    : > "$CAPTURED_REQUESTS"
+}
+
+# ---------------------------------------------------------------------------
+describe "user_prompt_expansion.sh"
+# ---------------------------------------------------------------------------
+
+t_expansion_merges_current_turn_metadata() {
+    _with_turn_started "sess-upe-merge"
+    local transcript="$TEST_TMP/transcript.jsonl"
+    _skill_listing_transcript "$transcript"
+
+    run_hook user_prompt_expansion.sh "$(_fixture_user_prompt_expansion "sess-upe-merge" "/review" "$transcript")"
+    assert_success "$HOOK_STATUS"
+
+    local span
+    span=$(all_spans | jq -c '.[0]')
+    assert_eq "$(echo "$span" | jq -r '._is_merge')" "true"
+    assert_eq "$(echo "$span" | jq -r '.metadata.loaded_skill_names[0]')" "review"
+    assert_eq "$(echo "$span" | jq -r '.metadata.loaded_skills[0].name')" "review"
+}
+
+t_pending_expansion_is_added_to_next_turn() {
+    _with_started_session "sess-upe-pending"
+    local transcript="$TEST_TMP/transcript.jsonl"
+    _skill_listing_transcript "$transcript"
+
+    run_hook user_prompt_expansion.sh "$(_fixture_user_prompt_expansion "sess-upe-pending" "/review" "$transcript")"
+    assert_success "$HOOK_STATUS"
+    : > "$CAPTURED_REQUESTS"
+
+    run_hook user_prompt_submit.sh "$(fixture_user_prompt "sess-upe-pending" "after expansion")"
+    assert_success "$HOOK_STATUS"
+
+    local turn
+    turn=$(span_by_name "^Turn 1$")
+    assert_eq "$(echo "$turn" | jq -r '.metadata.loaded_skill_names[0]')" "review"
+    assert_eq "$(echo "$turn" | jq -r '.metadata.loaded_skills[0].name')" "review"
+}
+
+t_matching_skill_tool_is_marked_explicit() {
+    _with_turn_started "sess-upe-tool"
+    local transcript="$TEST_TMP/transcript.jsonl"
+    _skill_listing_transcript "$transcript"
+
+    run_hook user_prompt_expansion.sh "$(_fixture_user_prompt_expansion "sess-upe-tool" "/review" "$transcript")"
+    assert_success "$HOOK_STATUS"
+    : > "$CAPTURED_REQUESTS"
+
+    run_hook post_tool_use.sh "$(fixture_post_tool_use "sess-upe-tool" "Skill" \
+        "$(jq -nc '{name: "review"}')" \
+        "$(fixture_tool_response_text 'loaded')")"
+
+    local tool_span
+    tool_span=$(span_by_type "tool")
+    assert_eq "$(echo "$tool_span" | jq -r '.metadata.skill_load_trigger')" "explicit"
+}
+
+t_non_skill_slash_command_is_ignored() {
+    _with_turn_started "sess-upe-ignore"
+    local transcript="$TEST_TMP/transcript.jsonl"
+    _skill_listing_transcript "$transcript"
+
+    run_hook user_prompt_expansion.sh "$(_fixture_user_prompt_expansion "sess-upe-ignore" "/not-a-skill" "$transcript")"
+    assert_success "$HOOK_STATUS"
+
+    assert_eq "$(span_count)" "0"
+}
+
+it "merges explicit skill metadata onto the current turn" t_expansion_merges_current_turn_metadata
+it "adds pending explicit skill metadata to the next turn" t_pending_expansion_is_added_to_next_turn
+it "marks matching Skill tool spans as explicit" t_matching_skill_tool_is_marked_explicit
+it "ignores slash commands not present in skill listings" t_non_skill_slash_command_is_ignored


### PR DESCRIPTION
## Summary

Implements explicit skill request capture for Claude tracing while preserving raw tool names for observed skill loads.

- Records explicit skill requests on turn metadata via `loaded_skill_names` and `loaded_skills`.
- Marks matching Claude `Skill` tool spans with `skill_load_trigger: "explicit"`.
- Preserves `metadata.tool_name` as the raw Claude tool name (`Skill`) and adds `metadata.tool_kind: "skill"` for skill-load classification.

## Validation

- `test/run_tests.sh`
- `bash test/test_post_tool_use.sh`