### PR TITLE
Capture repo attribution metadata

### DIFF
--- a/plugins/trace-claude-code/hooks/common.sh
+++ b/plugins/trace-claude-code/hooks/common.sh
@@ -890,6 +890,47 @@ get_os() {
     uname -s 2>/dev/null || echo "unknown"
 }
 
+redact_git_remote_url() {
+    local remote="$1"
+    [ -z "$remote" ] && return 0
+
+    case "$remote" in
+        *://*@*)
+            local scheme="${remote%%://*}"
+            local rest="${remote#*://}"
+            echo "${scheme}://${rest#*@}"
+            ;;
+        *)
+            echo "$remote"
+            ;;
+    esac
+}
+
+git_metadata_json() {
+    local cwd="$1"
+    if [ -z "$cwd" ]; then
+        echo '{}'
+        return 0
+    fi
+
+    local origin branch commit
+    origin=$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" remote get-url origin 2>/dev/null || true)
+    branch=$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+    commit=$(GIT_OPTIONAL_LOCKS=0 git -C "$cwd" rev-parse HEAD 2>/dev/null || true)
+
+    origin=$(redact_git_remote_url "$origin")
+
+    jq -cn \
+        --arg origin "$origin" \
+        --arg branch "$branch" \
+        --arg commit "$commit" \
+        '{
+            git_origin_url: $origin,
+            git_branch: $branch,
+            git_commit_sha: $commit
+        } | with_entries(select(.value != ""))'
+}
+
 # Version of this plugin, read from its plugin.json manifest. Cached after the
 # first lookup. Returns "unknown" if it can't be read.
 get_plugin_version() {

--- a/plugins/trace-claude-code/hooks/session_start.sh
+++ b/plugins/trace-claude-code/hooks/session_start.sh
@@ -81,6 +81,7 @@ OS=$(get_os)
 TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
 PLUGIN_VERSION=$(get_plugin_version)
 CLAUDE_CODE_VERSION=$(get_claude_code_version "$TRANSCRIPT_PATH")
+GIT_METADATA=$(git_metadata_json "$WORKSPACE")
 
 EVENT=$(jq -n \
     --arg id "$SPAN_ID" \
@@ -95,13 +96,14 @@ EVENT=$(jq -n \
     --arg os "$OS" \
     --arg plugin_version "$PLUGIN_VERSION" \
     --arg claude_code_version "$CLAUDE_CODE_VERSION" \
+    --argjson git_metadata "$GIT_METADATA" \
     '{
         id: $id,
         span_id: $span_id,
         root_span_id: $root_span_id,
         created: $created,
         input: ("Session: " + $workspace),
-        metadata: {
+        metadata: ({
             session_id: $session,
             workspace: $cwd,
             hostname: $hostname,
@@ -110,7 +112,7 @@ EVENT=$(jq -n \
             source: "claude-code",
             trace_claude_code_version: $plugin_version,
             claude_code_version: $claude_code_version
-        },
+        } + $git_metadata),
         span_attributes: {
             name: ("Claude Code: " + $workspace),
             type: "task"

--- a/plugins/trace-claude-code/hooks/user_prompt_submit.sh
+++ b/plugins/trace-claude-code/hooks/user_prompt_submit.sh
@@ -53,6 +53,7 @@ if [ -z "$ROOT_SPAN_ID" ] || [ -z "$PROJECT_ID" ]; then
     TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
     PLUGIN_VERSION=$(get_plugin_version)
     CLAUDE_CODE_VERSION=$(get_claude_code_version "$TRANSCRIPT_PATH")
+    GIT_METADATA=$(git_metadata_json "$CWD")
 
     EVENT=$(jq -n \
         --arg id "$ROOT_SPAN_ID" \
@@ -66,13 +67,14 @@ if [ -z "$ROOT_SPAN_ID" ] || [ -z "$PROJECT_ID" ]; then
         --arg os "$OS" \
         --arg plugin_version "$PLUGIN_VERSION" \
         --arg claude_code_version "$CLAUDE_CODE_VERSION" \
+        --argjson git_metadata "$GIT_METADATA" \
         '{
             id: $id,
             span_id: $span_id,
             root_span_id: $root_span_id,
             created: $created,
             input: ("Session: " + $workspace),
-            metadata: {
+            metadata: ({
                 session_id: $session,
                 workspace: $workspace,
                 hostname: $hostname,
@@ -81,7 +83,7 @@ if [ -z "$ROOT_SPAN_ID" ] || [ -z "$PROJECT_ID" ]; then
                 source: "claude-code",
                 trace_claude_code_version: $plugin_version,
                 claude_code_version: $claude_code_version
-            },
+            } + $git_metadata),
             span_attributes: {
                 name: ("Claude Code: " + $workspace),
                 type: "task"

--- a/plugins/trace-claude-code/test/test_common.sh
+++ b/plugins/trace-claude-code/test/test_common.sh
@@ -209,6 +209,59 @@ it "returns a non-empty lowercase UUID"        t_uuid_format
 it "returns unique values on subsequent calls" t_uuid_unique
 
 # ---------------------------------------------------------------------------
+describe "git metadata helpers"
+# ---------------------------------------------------------------------------
+
+_make_git_repo() {
+    local dir
+    dir=$(mktemp -d)
+    git -C "$dir" init >/dev/null 2>&1
+    git -C "$dir" config user.email test@example.com
+    git -C "$dir" config user.name "Test User"
+    printf "hello\n" > "$dir/README.md"
+    git -C "$dir" add README.md
+    git -C "$dir" commit -m init >/dev/null 2>&1
+    git -C "$dir" branch -M main
+    git -C "$dir" remote add origin "https://token@github.com/acme/app.git"
+    echo "$dir"
+}
+
+t_git_remote_redaction() {
+    local redacted
+    redacted=$(redact_git_remote_url "https://token:secret@github.com/acme/app.git")
+    assert_eq "$redacted" "https://github.com/acme/app.git"
+
+    local ssh
+    ssh=$(redact_git_remote_url "git@github.com:acme/app.git")
+    assert_eq "$ssh" "git@github.com:acme/app.git"
+}
+
+t_git_metadata_json() {
+    local repo commit metadata
+    repo=$(_make_git_repo)
+    commit=$(git -C "$repo" rev-parse HEAD)
+    metadata=$(git_metadata_json "$repo")
+
+    assert_eq "$(echo "$metadata" | jq -r '.git_origin_url')" "https://github.com/acme/app.git"
+    assert_eq "$(echo "$metadata" | jq -r '.git_branch')" "main"
+    assert_eq "$(echo "$metadata" | jq -r '.git_commit_sha')" "$commit"
+
+    rm -rf "$repo"
+}
+
+t_git_metadata_json_not_git() {
+    local dir metadata
+    dir=$(mktemp -d)
+    metadata=$(git_metadata_json "$dir")
+    assert_eq "$metadata" "{}"
+    rm -rf "$dir"
+}
+
+it "redacts URL-style git remote credentials" t_git_remote_redaction
+it "captures origin, branch, and commit"      t_git_metadata_json
+it "omits fields outside a git repo"          t_git_metadata_json_not_git
+
+# ---------------------------------------------------------------------------
 describe "record_hook_input: event labeling and transcript snapshots"
 # ---------------------------------------------------------------------------
 

--- a/plugins/trace-claude-code/test/test_session_start.sh
+++ b/plugins/trace-claude-code/test/test_session_start.sh
@@ -95,6 +95,39 @@ t_session_start_metadata() {
     assert_ne "$cc_version" "" "claude_code_version should be non-empty"
 }
 
+_make_git_repo() {
+    local dir
+    dir=$(mktemp -d)
+    git -C "$dir" init >/dev/null 2>&1
+    git -C "$dir" config user.email test@example.com
+    git -C "$dir" config user.name "Test User"
+    printf "hello\n" > "$dir/README.md"
+    git -C "$dir" add README.md
+    git -C "$dir" commit -m init >/dev/null 2>&1
+    git -C "$dir" branch -M main
+    git -C "$dir" remote add origin "https://token@github.com/acme/app.git"
+    echo "$dir"
+}
+
+t_session_start_git_metadata() {
+    _setup_default_stubs
+
+    local repo commit
+    repo=$(_make_git_repo)
+    commit=$(git -C "$repo" rev-parse HEAD)
+
+    run_hook session_start.sh "$(fixture_session_start "sess-git" "$repo")"
+
+    local span
+    span=$(span_by_type "task")
+
+    assert_eq "$(echo "$span" | jq -r '.metadata.git_origin_url')" "https://github.com/acme/app.git"
+    assert_eq "$(echo "$span" | jq -r '.metadata.git_branch')" "main"
+    assert_eq "$(echo "$span" | jq -r '.metadata.git_commit_sha')" "$commit"
+
+    rm -rf "$repo"
+}
+
 t_session_start_writes_state() {
     _setup_default_stubs
 
@@ -117,6 +150,7 @@ t_session_start_writes_state() {
 it "creates exactly one root session span"  t_session_start_creates_one_span
 it "span has correct name, id, and type"    t_session_start_span_shape
 it "span includes claude-code metadata"     t_session_start_metadata
+it "span includes minimal git metadata"     t_session_start_git_metadata
 it "persists session state for later hooks" t_session_start_writes_state
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Capture minimal Git attribution metadata on Claude Code tracing root spans.
- Add best-effort shell helpers for redacted origin URL, branch, and commit SHA.
- Apply metadata in both normal session start and fallback root creation paths.

## Validation

- `bash test/run_tests.sh`