### PR TITLE
chore(release): bump plugin versions

### DIFF
--- a/plugins/braintrust/.claude-plugin/plugin.json
+++ b/plugins/braintrust/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "braintrust",
   "displayName": "Braintrust",
   "description": "Enables AI agents to use Braintrust for LLM evaluation, logging, and observability. Provides correct API usage, working examples, and helper scripts for common operations.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": {
     "name": "Braintrust",
     "email": "support@braintrust.dev",

--- a/plugins/trace-claude-code/.claude-plugin/plugin.json
+++ b/plugins/trace-claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "trace-claude-code",
   "description": "Automatically trace Claude Code conversations to Braintrust for observability. Captures sessions, conversation turns, and tool calls as hierarchical traces.",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "author": {
     "name": "Braintrust"
   }


### PR DESCRIPTION
Release changelog:

braintrust 1.3.2:
- Add expanded Claude plugin manifest metadata for marketplace compatibility.

trace-claude-code 1.5.0:
- Emit canonical cache token metrics.
- Capture implicit and explicit skill usage.
- Attach repository attribution metadata.