### PR TITLE
Sanitize credentials in traced telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ $HOME/.claude/plugins/marketplaces/braintrust-claude-plugin/plugins/trace-claude
 
 Traces are sent to the `claude-code` project by default.
 
+#### Telemetry sanitization
+
+Captured telemetry is sanitized before it is queued or sent to Braintrust and
+before hook payloads, transcript fixtures, or diagnostic messages are written
+locally. The sanitizer redacts sensitive JSON fields, shell environment
+assignments, credential CLI flags, bearer authorization headers, common
+Braintrust/OpenAI/Anthropic, GitHub, and Slack token formats, and PEM private
+keys. Sanitized values use the `[REDACTED]` placeholder. The configured
+`BRAINTRUST_API_KEY` is still used unchanged for the transport Authorization
+header and is not included in telemetry.
+
 #### manual configuration
 
 Instead of running `setup.sh`, you can manually edit `~/.claude/settings.json` or your project's `.claude/settings.local.json`:

--- a/plugins/trace-claude-code/.claude-plugin/plugin.json
+++ b/plugins/trace-claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "trace-claude-code",
   "description": "Automatically trace Claude Code conversations to Braintrust for observability. Captures sessions, conversation turns, and tool calls as hierarchical traces.",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "Braintrust"
   }

--- a/plugins/trace-claude-code/hooks/common.sh
+++ b/plugins/trace-claude-code/hooks/common.sh
@@ -49,8 +49,117 @@ mkdir -p "$(dirname "$CACHE_FILE")"
 mkdir -p "$SESSION_STATE_DIR"
 mkdir -p "$QUEUE_DIR"
 
-# Logging (defined early so other functions can use it)
-log() { echo "$(date '+%Y-%m-%d %H:%M:%S') [$1] $2" >> "$LOG_FILE"; }
+# Telemetry sanitization
+#
+# These filters are centralized here so every hook, queue writer, worker, log,
+# and recording path uses the same rules. The final queue and HTTP boundaries
+# call sanitize_span_event() unconditionally; earlier calls keep secrets out of
+# display names and local diagnostic files as well.
+export BRAINTRUST_REDACTION_PLACEHOLDER="[REDACTED]"
+
+_SANITIZE_JQ_FILTER='
+    def sensitive_key:
+        ascii_downcase
+        | gsub("[^a-z0-9]+"; "_")
+        | gsub("^_+|_+$"; "")
+        | test("(^|_)(api_key|apikey|authorization|access_token|accesstoken|refresh_token|refreshtoken|token|secret|client_secret|clientsecret|password|passwd|credential|credentials)$");
+
+    def redact_configured_secret:
+        if ($configured_secret | length) > 0 then
+            split($configured_secret) | join("[REDACTED]")
+        else
+            .
+        end;
+
+    def redact_text:
+        redact_configured_secret
+        # PEM-encoded private keys, including RSA/EC/OpenSSH variants.
+        | gsub("(?s)-----BEGIN[[:space:]]+(?:[A-Z0-9]+[[:space:]]+)*PRIVATE[[:space:]]+KEY-----.*?-----END[[:space:]]+(?:[A-Z0-9]+[[:space:]]+)*PRIVATE[[:space:]]+KEY-----"; "[REDACTED]")
+        # Authorization headers.
+        | gsub("(?i)(?<prefix>authorization[[:space:]]*:[[:space:]]*bearer[[:space:]]+)(?:\\\"[^\\\"]*\\\"|\\x27[^\\x27]*\\x27|[^[:space:],;\\\"\\x27]+)"; "\(.prefix)[REDACTED]")
+        # Quoted and unquoted shell-style sensitive assignments. Requiring a
+        # complete sensitive suffix avoids matching words such as `monkey`.
+        | gsub("(?i)(?<prefix>(^|[^a-z0-9_])(?:export[[:space:]]+)?(?:[a-z][a-z0-9]*_)*(?:api_key|apikey|authorization|access_token|refresh_token|token|secret|client_secret|password|passwd|credential|credentials)[[:space:]]*=[[:space:]]*)(?:\\\"[^\\\"]*\\\"|\\x27[^\\x27]*\\x27|[^[:space:];,\\\"\\x27]+)"; "\(.prefix)[REDACTED]")
+        # Sensitive CLI options with either `--flag value` or `--flag=value`.
+        | gsub("(?i)(?<prefix>(^|[[:space:];])--(?:api[-_]?key|access[-_]?token|refresh[-_]?token|token|secret|client[-_]?secret|password|passwd|credential|credentials)(?:[[:space:]]+|[[:space:]]*=[[:space:]]*))(?:\\\"[^\\\"]*\\\"|\\x27[^\\x27]*\\x27|[^[:space:];,\\\"\\x27]+)"; "\(.prefix)[REDACTED]")
+        # Standalone provider credential formats. The sk- rule requires a
+        # substantial token body so ordinary names such as `ask-user` and
+        # `task-status` remain intact; short values are still caught when
+        # they appear in known assignments or sensitive JSON fields.
+        | gsub("(?<prefix>(^|[^A-Za-z0-9_-]))sk-(?:(?:proj|svcacct|ant-api[0-9]+)-)?[A-Za-z0-9_=-]{16,}"; "\(.prefix)[REDACTED]")
+        | gsub("(?<prefix>(^|[^A-Za-z0-9_]))(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})"; "\(.prefix)[REDACTED]")
+        | gsub("(?<prefix>(^|[^A-Za-z0-9-]))(?:xox[baprsce]|xapp)-[A-Za-z0-9-]{10,}"; "\(.prefix)[REDACTED]");
+
+    def sanitize_value:
+        if type == "object" then
+            with_entries(
+                if (.key | sensitive_key) then
+                    .value = "[REDACTED]"
+                else
+                    .value |= sanitize_value
+                end
+            )
+        elif type == "array" then
+            map(sanitize_value)
+        elif type == "string" then
+            # Tool-call arguments are often JSON serialized inside a string.
+            # Parse and recursively sanitize those values when possible, then
+            # restore their string representation for schema compatibility.
+            . as $text
+            | try (fromjson | sanitize_value | tojson)
+              catch ($text | redact_text)
+        else
+            .
+        end;
+'
+
+# Sanitize arbitrary free-form text. If jq is unavailable or a filter fails,
+# fail closed instead of writing the original value to a persistence surface.
+sanitize_text() {
+    local value="${1-}"
+    local sanitized
+    sanitized=$(printf '%s' "$value" | jq -Rrs \
+        --arg configured_secret "${API_KEY:-}" \
+        "${_SANITIZE_JQ_FILTER} redact_text" 2>/dev/null) || {
+        printf '%s\n' "$BRAINTRUST_REDACTION_PLACEHOLDER"
+        return 0
+    }
+    printf '%s\n' "$sanitized"
+}
+
+# Recursively sanitize JSON objects and arrays. Sensitive field names are
+# matched case-insensitively after punctuation normalization, while every
+# string value also receives the free-form credential filters above.
+sanitize_json() {
+    local value="${1-}"
+    printf '%s' "$value" | jq -c \
+        --arg configured_secret "${API_KEY:-}" \
+        "${_SANITIZE_JQ_FILTER} sanitize_value" 2>/dev/null
+}
+
+# Sanitize and validate a complete span event. Callers must treat failure as
+# fatal for that event; returning raw JSON would make the queue boundary
+# bypassable.
+sanitize_span_event() {
+    local event_json="${1-}"
+    printf '%s' "$event_json" | jq -c \
+        --arg configured_secret "${API_KEY:-}" \
+        "${_SANITIZE_JQ_FILTER}
+        if type == \"object\" then sanitize_value else error(\"span event must be an object\") end" \
+        2>/dev/null
+}
+
+# Logging is sanitized by default so normal, warning, error, and debug paths
+# cannot accidentally persist caller-controlled payloads or API responses.
+log() {
+    local level message
+    case "$1" in
+        DEBUG|INFO|WARN|ERROR) level="$1" ;;
+        *) level="INFO" ;;
+    esac
+    message=$(sanitize_text "$2")
+    printf '%s [%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$level" "$message" >> "$LOG_FILE"
+}
 
 # Check if a value is truthy (true, 1, yes, on - case insensitive)
 is_truthy() {
@@ -88,12 +197,15 @@ record_hook_input() {
     ts=$(get_timestamp 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%S.000Z")
     events_file="$BRAINTRUST_RECORD_DIR/events.ndjson"
 
-    # Build the record. payload may already be valid JSON; if not, treat as string.
+    # Build the record. payload may already be valid JSON; if not, treat as a
+    # sanitized string. Never persist the original hook payload.
     local payload_field
     if [ -n "$payload" ] && echo "$payload" | jq -e . >/dev/null 2>&1; then
-        payload_field=$(echo "$payload" | jq -c .)
+        payload_field=$(sanitize_json "$payload") || return 0
     else
-        payload_field=$(jq -nc --arg p "$payload" '$p')
+        local sanitized_payload
+        sanitized_payload=$(sanitize_text "$payload")
+        payload_field=$(jq -nc --arg p "$sanitized_payload" '$p')
     fi
 
     # Always label the event with Claude Code's canonical event name. The
@@ -113,6 +225,7 @@ record_hook_input() {
         --arg hook "$hook_name" \
         --argjson payload "$payload_field" \
         '{ts: $ts, hook: $hook, payload: $payload}' 2>/dev/null) || return 0
+    record=$(sanitize_json "$record") || return 0
 
     # Atomic append: claim an exclusive lock via mkdir, write, release.
     # Parallel PostToolUse hooks can otherwise interleave bytes into the
@@ -167,7 +280,7 @@ record_hook_input() {
         return 0
     fi
 
-    # Snapshot any transcript files referenced by this event so the
+    # Snapshot sanitized transcript files referenced by this event so the
     # recording can be replayed deterministically. (Path rewriting from
     # absolute to fixture-relative happens at replay time in
     # test/helpers/replay.sh, not here; we only copy the files.)
@@ -185,9 +298,29 @@ record_hook_input() {
     _snapshot_transcript() {
         local src="$1"
         [ -n "$src" ] && [ -f "$src" ] || return 0
-        local base
-        base=$(basename "$src")
-        cp "$src" "$BRAINTRUST_RECORD_DIR/transcripts/$base" 2>/dev/null || true
+        local base dest tmp line sanitized_line
+        base=$(sanitize_text "$(basename "$src")")
+        [ -n "$base" ] || base="transcript.jsonl"
+        dest="$BRAINTRUST_RECORD_DIR/transcripts/$base"
+        tmp="${dest}.tmp.$$"
+        : > "$tmp" 2>/dev/null || return 0
+
+        # Transcript fixtures are JSONL. Sanitize each object recursively;
+        # malformed lines fail closed to the text sanitizer instead of being
+        # copied verbatim.
+        while IFS= read -r line || [ -n "$line" ]; do
+            if [ -n "$line" ] && printf '%s' "$line" | jq -e . >/dev/null 2>&1; then
+                sanitized_line=$(sanitize_json "$line") || sanitized_line="$BRAINTRUST_REDACTION_PLACEHOLDER"
+            else
+                sanitized_line=$(sanitize_text "$line")
+            fi
+            printf '%s\n' "$sanitized_line" >> "$tmp" 2>/dev/null || {
+                rm -f "$tmp"
+                return 0
+            }
+        done < "$src"
+
+        mv "$tmp" "$dest" 2>/dev/null || rm -f "$tmp"
     }
 
     case "$hook_name" in
@@ -256,7 +389,7 @@ resolve_api_url() {
     fi
 
     if [ "$http_code" != "200" ]; then
-        log "WARN" "Braintrust login endpoint returned HTTP $http_code at $APP_URL/api/apikey/login: $resp"
+        log "WARN" "Braintrust login endpoint returned HTTP $http_code at $APP_URL/api/apikey/login"
     fi
 
     local api_url
@@ -328,7 +461,7 @@ get_project_id() {
     resp=$(echo "$resp" | sed '$d')
 
     if [ "$http_code" = "401" ] || [ "$http_code" = "403" ]; then
-        log "ERROR" "Braintrust authentication failed (HTTP $http_code) - BRAINTRUST_API_KEY is invalid, expired, or lacks permission. Get a new key at $APP_URL/app/settings?subroute=api-keys and set BRAINTRUST_API_KEY. Response: $resp"
+        log "ERROR" "Braintrust authentication failed (HTTP $http_code) - BRAINTRUST_API_KEY is invalid, expired, or lacks permission. Get a new key at $APP_URL/app/settings?subroute=api-keys and set BRAINTRUST_API_KEY"
         return 1
     fi
 
@@ -342,7 +475,7 @@ get_project_id() {
     fi
 
     if [ "$http_code" != "200" ] && [ "$http_code" != "404" ]; then
-        log "WARN" "Project lookup returned HTTP $http_code at $api_url/v1/project: $resp"
+        log "WARN" "Project lookup returned HTTP $http_code at $api_url/v1/project"
     fi
 
     # Create project. Build the JSON body with jq so any special chars
@@ -357,7 +490,7 @@ get_project_id() {
     resp=$(echo "$resp" | sed '$d')
 
     if [ "$http_code" = "401" ] || [ "$http_code" = "403" ]; then
-        log "ERROR" "Braintrust authentication failed (HTTP $http_code) while creating project '$name' - BRAINTRUST_API_KEY is invalid, expired, or lacks permission. Get a new key at $APP_URL/app/settings?subroute=api-keys. Response: $resp"
+        log "ERROR" "Braintrust authentication failed (HTTP $http_code) while creating project '$name' - BRAINTRUST_API_KEY is invalid, expired, or lacks permission. Get a new key at $APP_URL/app/settings?subroute=api-keys"
         return 1
     fi
 
@@ -369,7 +502,7 @@ get_project_id() {
         return 0
     fi
 
-    log "ERROR" "Failed to create project '$name' (HTTP $http_code) at $api_url/v1/project: $resp"
+    log "ERROR" "Failed to create project '$name' (HTTP $http_code) at $api_url/v1/project"
     return 1
 }
 
@@ -404,8 +537,20 @@ _http_insert_span() {
         log "ERROR" "Insert aborted: failed to add span origin context"
         return 1
     }
+    # Mandatory final outbound scrub. This also protects jobs written by an
+    # older plugin version and future callers that forget earlier sanitizers.
+    event_json=$(sanitize_span_event "$event_json") || {
+        log "ERROR" "Insert aborted: event sanitization failed"
+        return 1
+    }
 
-    debug "Inserting span: $(echo "$event_json" | jq -c '.')"
+    if is_truthy "$DEBUG"; then
+        local debug_span_id debug_span_name debug_span_type
+        debug_span_id=$(echo "$event_json" | jq -r '.span_id // .id // "unknown"' 2>/dev/null)
+        debug_span_name=$(echo "$event_json" | jq -r '.span_attributes.name // "unnamed"' 2>/dev/null)
+        debug_span_type=$(echo "$event_json" | jq -r '.span_attributes.type // "unknown"' 2>/dev/null)
+        debug "Inserting span id=$debug_span_id name=$debug_span_name type=$debug_span_type"
+    fi
 
     if [ -z "$API_KEY" ]; then
         log "ERROR" "API_KEY is empty - check BRAINTRUST_API_KEY env var"
@@ -436,7 +581,7 @@ _http_insert_span() {
     resp=$(echo "$resp" | sed '$d')
 
     if [ "$http_code" != "200" ]; then
-        log "ERROR" "Insert failed (HTTP $http_code) to $endpoint: $resp"
+        log "ERROR" "Insert failed (HTTP $http_code) to $endpoint"
         return 1
     fi
 
@@ -447,7 +592,7 @@ _http_insert_span() {
         echo "$row_id"
         return 0
     else
-        log "WARN" "Insert returned empty row_ids: $resp"
+        log "WARN" "Insert returned empty row_ids"
         return 1
     fi
 }
@@ -584,6 +729,13 @@ enqueue_span() {
         log "ERROR" "enqueue_span called without session_id"
         return 1
     fi
+
+    # Mandatory persistence-boundary scrub. The queue never receives a raw
+    # span event, even when a hook omits earlier sanitization.
+    event_json=$(sanitize_span_event "$event_json") || {
+        log "ERROR" "enqueue_span rejected an invalid span event"
+        return 1
+    }
 
     # Build the job JSON
     local job
@@ -1174,6 +1326,7 @@ emit_llm_spans_from_transcript() {
     local dir
     while IFS= read -r dir; do
         [ -z "$dir" ] && continue
+        dir=$(sanitize_json "$dir") || continue
 
         local kind ts epoch span_id
         kind=$(echo "$dir" | jq -r '.kind')
@@ -1281,24 +1434,28 @@ emit_llm_spans_from_transcript() {
 _subagent_tool_span_name() {
     local tool_name="$1"
     local tool_input="$2"
+    tool_name=$(sanitize_text "$tool_name")
+    tool_input=$(sanitize_json "$tool_input") || tool_input='{}'
+    local span_name
     case "$tool_name" in
         Read|Write|Edit|MultiEdit)
             local fp
             fp=$(echo "$tool_input" | jq -r '(. | (try fromjson catch .)) | (.file_path // .path // empty)' 2>/dev/null)
-            [ -n "$fp" ] && echo "$tool_name: $(basename "$fp")" || echo "$tool_name"
+            [ -n "$fp" ] && span_name="$tool_name: $(basename "$fp")" || span_name="$tool_name"
             ;;
         Bash|Terminal)
             local cmd
             cmd=$(echo "$tool_input" | jq -r '(. | (try fromjson catch .)) | (.command // empty)' 2>/dev/null | head -c 50)
-            echo "Terminal: ${cmd:-command}"
+            span_name="Terminal: ${cmd:-command}"
             ;;
         mcp__*)
-            echo "$tool_name" | sed 's/mcp__/MCP: /' | sed 's/__/ - /'
+            span_name=$(echo "$tool_name" | sed 's/mcp__/MCP: /' | sed 's/__/ - /')
             ;;
         *)
-            echo "$tool_name"
+            span_name="$tool_name"
             ;;
     esac
+    sanitize_text "$span_name"
 }
 
 # Convert an ISO-8601 timestamp (UTC, e.g. 2026-06-11T03:01:33.000Z) to a

--- a/plugins/trace-claude-code/hooks/post_tool_use.sh
+++ b/plugins/trace-claude-code/hooks/post_tool_use.sh
@@ -16,13 +16,19 @@ check_requirements || exit 0
 # Read input from stdin
 INPUT=$(cat)
 record_hook_input "post_tool_use" "$INPUT"
-debug "PostToolUse input: $(echo "$INPUT" | jq -c '.' 2>/dev/null | head -c 500)"
 
 # Extract tool info
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 TOOL_INPUT=$(echo "$INPUT" | jq -c '.tool_input // {}' 2>/dev/null)
 TOOL_OUTPUT=$(echo "$INPUT" | jq -c '.tool_response // .output // {}' 2>/dev/null)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+
+# Sanitize captured telemetry before it can influence a span display name or
+# event body. enqueue_span() performs a second mandatory boundary scrub.
+TOOL_NAME=$(sanitize_text "$TOOL_NAME")
+TOOL_INPUT=$(sanitize_json "$TOOL_INPUT") || TOOL_INPUT='{}'
+TOOL_OUTPUT=$(sanitize_json "$TOOL_OUTPUT") || TOOL_OUTPUT='{}'
+debug "PostToolUse payload received tool=$TOOL_NAME session=$SESSION_ID"
 
 # Skip if no tool name
 [ -z "$TOOL_NAME" ] && { debug "No tool name, skipping"; exit 0; }
@@ -95,6 +101,7 @@ case "$TOOL_NAME" in
         SPAN_NAME="$TOOL_NAME"
         ;;
 esac
+SPAN_NAME=$(sanitize_text "$SPAN_NAME")
 
 # Build the event - tool is child of Turn
 EVENT=$(jq -n \

--- a/plugins/trace-claude-code/hooks/session_end.sh
+++ b/plugins/trace-claude-code/hooks/session_end.sh
@@ -18,11 +18,11 @@ check_requirements || exit 0
 # Read input from stdin
 INPUT=$(cat)
 record_hook_input "session_end" "$INPUT"
-debug "SessionEnd input: $(echo "$INPUT" | jq -c '.' 2>/dev/null | head -c 500)"
 
 # Extract session ID. Claude Code always sends one; if it doesn't, there's
 # nothing we can drain (per-session queues are keyed by session id).
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+debug "SessionEnd payload received session=$SESSION_ID"
 [ -z "$SESSION_ID" ] && { debug "No session ID in payload, skipping"; exit 0; }
 
 # Log a one-line session summary for observability. State may be partial

--- a/plugins/trace-claude-code/hooks/session_start.sh
+++ b/plugins/trace-claude-code/hooks/session_start.sh
@@ -17,7 +17,7 @@ check_requirements || exit 0
 # Read input from stdin
 INPUT=$(cat)
 record_hook_input "session_start" "$INPUT"
-debug "SessionStart input: $INPUT"
+debug "SessionStart payload received"
 
 # Extract session ID from input
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)

--- a/plugins/trace-claude-code/hooks/stop_hook.sh
+++ b/plugins/trace-claude-code/hooks/stop_hook.sh
@@ -40,7 +40,6 @@ check_requirements || exit 0
 # Read input from stdin
 INPUT=$(cat)
 record_hook_input "stop_hook" "$INPUT"
-debug "Stop input: $(echo "$INPUT" | jq -c '.' 2>/dev/null | head -c 500)"
 
 # Get session ID
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
@@ -58,6 +57,8 @@ fi
 # payload, so we don't have to reconstruct it from the transcript.
 # (See https://docs.claude.com/en/docs/claude-code/hooks -> Stop input)
 LAST_ASSISTANT_MESSAGE=$(echo "$INPUT" | jq -r '.last_assistant_message // empty' 2>/dev/null)
+LAST_ASSISTANT_MESSAGE=$(sanitize_text "$LAST_ASSISTANT_MESSAGE")
+debug "Stop payload received session=$SESSION_ID"
 
 # Get session state
 ROOT_SPAN_ID=$(get_session_state "$SESSION_ID" "root_span_id")
@@ -143,6 +144,11 @@ add_to_history() {
     local content="$2"
     local tool_call_id="$3"
     local tool_calls="$4"
+
+    content=$(sanitize_text "$content")
+    if [ -n "$tool_calls" ] && [ "$tool_calls" != "[]" ]; then
+        tool_calls=$(sanitize_json "$tool_calls") || tool_calls='[]'
+    fi
 
     if [ "$role" = "tool" ]; then
         CONVERSATION_HISTORY=$(echo "$CONVERSATION_HISTORY" | jq --arg role "$role" --arg content "$content" --arg id "$tool_call_id" \
@@ -375,6 +381,7 @@ while IFS= read -r line; do
                 empty
               end
         ' 2>/dev/null)
+        TEXT=$(sanitize_text "$TEXT")
 
         # Extract full tool_use objects for tool_calls
         TOOL_CALLS_JSON=$(echo "$line" | jq -c '
@@ -392,6 +399,7 @@ while IFS= read -r line; do
                 []
               end
         ' 2>/dev/null)
+        TOOL_CALLS_JSON=$(sanitize_json "${TOOL_CALLS_JSON:-[]}") || TOOL_CALLS_JSON='[]'
 
         # Check if we have tool calls
         HAS_TOOL_CALLS=$(echo "$TOOL_CALLS_JSON" | jq 'length > 0' 2>/dev/null)

--- a/plugins/trace-claude-code/hooks/user_prompt_submit.sh
+++ b/plugins/trace-claude-code/hooks/user_prompt_submit.sh
@@ -16,11 +16,11 @@ check_requirements || exit 0
 # Read input from stdin
 INPUT=$(cat)
 record_hook_input "user_prompt_submit" "$INPUT"
-debug "UserPromptSubmit input: $(echo "$INPUT" | jq -c '.' 2>/dev/null | head -c 500)"
 
 # Extract session ID and prompt
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null)
+debug "UserPromptSubmit payload received session=$SESSION_ID"
 
 [ -z "$SESSION_ID" ] && { debug "No session ID"; exit 0; }
 

--- a/plugins/trace-claude-code/test/helpers/curl_stub.sh
+++ b/plugins/trace-claude-code/test/helpers/curl_stub.sh
@@ -86,7 +86,9 @@ curl() {
     local url=""
     local data=""
     local want_http_code=0
-    local arg
+    local auth_header_present=false
+    local auth_uses_configured_api_key=false
+    local arg header
 
     # Parse args. We handle the flags actually used by common.sh:
     #   -s          silent (ignore)
@@ -102,7 +104,18 @@ curl() {
             -s|--silent) shift ;;
             -f|--fail) shift ;;
             -X|--request) method="$2"; shift 2 ;;
-            -H|--header) shift 2 ;;
+            -H|--header)
+                header="$2"
+                case "$header" in
+                    Authorization:*|authorization:*|AUTHORIZATION:*)
+                        auth_header_present=true
+                        if [ "$header" = "Authorization: Bearer ${BRAINTRUST_API_KEY:-}" ]; then
+                            auth_uses_configured_api_key=true
+                        fi
+                        ;;
+                esac
+                shift 2
+                ;;
             -d|--data|--data-raw|--data-binary) data="$2"; shift 2 ;;
             -w|--write-out)
                 if [[ "$2" == *"%{http_code}"* ]]; then
@@ -148,7 +161,15 @@ curl() {
             --arg method "$method" \
             --arg url "$url" \
             --argjson data "$data_field" \
-            '{method: $method, url: $url, body: $data}' >> "$CAPTURED_REQUESTS"
+            --argjson auth_header_present "$auth_header_present" \
+            --argjson auth_uses_configured_api_key "$auth_uses_configured_api_key" \
+            '{
+                method: $method,
+                url: $url,
+                body: $data,
+                auth_header_present: $auth_header_present,
+                auth_uses_configured_api_key: $auth_uses_configured_api_key
+            }' >> "$CAPTURED_REQUESTS"
     fi
 
     # Find a matching response

--- a/plugins/trace-claude-code/test/test_sanitization.sh
+++ b/plugins/trace-claude-code/test/test_sanitization.sh
@@ -1,0 +1,371 @@
+#!/bin/bash
+###
+# Regression tests for credential sanitization across hook telemetry,
+# persistence, recordings, logs, and transport.
+###
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/assert.sh
+source "$SCRIPT_DIR/helpers/assert.sh"
+# shellcheck source=helpers/harness.sh
+source "$SCRIPT_DIR/helpers/harness.sh"
+
+_setup_insert_stub() {
+    stub_response_for "*/v1/project_logs/*/insert" 200 '{"row_ids":["row_secure"]}'
+}
+
+_set_transport_secret() {
+    local secret="$1"
+    export BRAINTRUST_API_KEY="$secret"
+    export API_KEY="$secret"
+}
+
+_activate_turn() {
+    local session_id="$1"
+    set_session_state "$session_id" "root_span_id" "root-$session_id"
+    set_session_state "$session_id" "session_span_id" "root-$session_id"
+    set_session_state "$session_id" "project_id" "proj-secure"
+    set_session_state "$session_id" "current_turn_span_id" "turn-$session_id"
+    set_session_state "$session_id" "current_turn_tool_count" "0"
+    set_session_state "$session_id" "turn_last_line" "0"
+}
+
+_assert_absent() {
+    local content="$1"
+    local secret="$2"
+    local message="$3"
+    assert_not_contains "$content" "$secret" "$message"
+}
+
+# ---------------------------------------------------------------------------
+describe "sanitize_text"
+# ---------------------------------------------------------------------------
+
+t_text_redacts_credential_forms() {
+    local input output slack_token
+    slack_token=$(printf '%s%s' 'xox' 'b-1234567890-abcdefghijklmnopqrstuvwxyz')
+    input=$(printf '%s\n' \
+        'BRAINTRUST_API_KEY=sk-xyz' \
+        'export OPENAI_API_KEY="openai short value"' \
+        "ANTHROPIC_API_KEY='anthropic-short'" \
+        'CUSTOM_API_KEY=custom-short-value' \
+        'SERVICE_TOKEN=service-token-value SERVICE_SECRET=service-secret-value DB_PASSWORD=db-password-value' \
+        'bt --api-key cli-api-value --token="cli token value"' \
+        'Authorization: Bearer bearer-value' \
+        'Authorization: Bearer "quoted-bearer-value"' \
+        'sk-proj-abcdefghijklmnopqrstuvwxyz0123456789' \
+        'ghp_abcdefghijklmnopqrstuvwxyz0123456789' \
+        "$slack_token" \
+        '-----BEGIN PRIVATE KEY-----' \
+        'private-key-body' \
+        '-----END PRIVATE KEY-----')
+
+    output=$(sanitize_text "$input")
+
+    for secret in \
+        sk-xyz \
+        "openai short value" \
+        anthropic-short \
+        custom-short-value \
+        service-token-value \
+        service-secret-value \
+        db-password-value \
+        cli-api-value \
+        "cli token value" \
+        bearer-value \
+        quoted-bearer-value \
+        sk-proj-abcdefghijklmnopqrstuvwxyz0123456789 \
+        ghp_abcdefghijklmnopqrstuvwxyz0123456789 \
+        "$slack_token" \
+        private-key-body; do
+        _assert_absent "$output" "$secret" "redacts $secret"
+    done
+    assert_contains "$output" "$BRAINTRUST_REDACTION_PLACEHOLDER" "uses the standard placeholder"
+}
+
+t_text_preserves_ordinary_values() {
+    local input output
+    input='task-status ask-user 123e4567-e89b-12d3-a456-426614174000 monkey keyboard normal-id-42'
+    output=$(sanitize_text "$input")
+    assert_eq "$output" "$input" "ordinary hyphenated names and identifiers remain unchanged"
+}
+
+t_text_redacts_multiple_secrets() {
+    local input output
+    input='OPENAI_API_KEY=first-short OTHER_TOKEN=second-short Authorization: Bearer third-short'
+    output=$(sanitize_text "$input")
+    _assert_absent "$output" "first-short" "first secret removed"
+    _assert_absent "$output" "second-short" "second secret removed"
+    _assert_absent "$output" "third-short" "third secret removed"
+    assert_eq "$(printf '%s' "$output" | grep -oF "$BRAINTRUST_REDACTION_PLACEHOLDER" | wc -l | tr -d ' ')" "3" "all secrets receive placeholders"
+}
+
+it "redacts assignments, CLI flags, headers, provider tokens, and PEM keys" t_text_redacts_credential_forms
+it "preserves task-status, ask-user, UUIDs, and ordinary words" t_text_preserves_ordinary_values
+it "redacts multiple secrets in one string" t_text_redacts_multiple_secrets
+
+# ---------------------------------------------------------------------------
+describe "sanitize_json and sanitize_span_event"
+# ---------------------------------------------------------------------------
+
+t_json_redacts_nested_sensitive_fields() {
+    local input output
+    input='{
+        "ApiKey":"one",
+        "AUTHORIZATION":"Bearer two",
+        "nested":[
+            {"access-token":"three","refresh_token":"four"},
+            {"clientSecret":"five","password":"six","credentials":{"user":"seven"}}
+        ],
+        "arguments":"{\"api_key\":\"eight\",\"command\":\"OTHER_SECRET=nine\"}",
+        "monkey":"banana",
+        "keyboard":"mechanical",
+        "key":"harmless-key",
+        "id":"123e4567-e89b-12d3-a456-426614174000"
+    }'
+    output=$(sanitize_json "$input")
+
+    for secret in one two three four five six seven eight nine; do
+        _assert_absent "$output" "$secret" "nested secret $secret removed"
+    done
+    assert_eq "$(echo "$output" | jq -r '.monkey')" "banana"
+    assert_eq "$(echo "$output" | jq -r '.keyboard')" "mechanical"
+    assert_eq "$(echo "$output" | jq -r '.key')" "harmless-key"
+    assert_eq "$(echo "$output" | jq -r '.id')" "123e4567-e89b-12d3-a456-426614174000"
+    assert_eq "$(echo "$output" | jq -r '.nested[0]["access-token"]')" "$BRAINTRUST_REDACTION_PLACEHOLDER"
+}
+
+t_span_event_sanitizes_all_payload_sections() {
+    local secret='sk-span-event-secret-1234567890'
+    local event output
+    event=$(jq -nc --arg secret "$secret" '{
+        id:"span-1",
+        input:{command:("BRAINTRUST_API_KEY=" + $secret)},
+        output:{stdout:("Authorization: Bearer " + $secret)},
+        metadata:{access_token:$secret, harmless_id:"normal-id"},
+        span_attributes:{name:("Terminal: BRAINTRUST_API_KEY=" + $secret), type:"tool"}
+    }')
+    output=$(sanitize_span_event "$event")
+
+    _assert_absent "$output" "$secret" "complete event is sanitized"
+    assert_eq "$(echo "$output" | jq -r '.metadata.harmless_id')" "normal-id"
+    assert_contains "$(echo "$output" | jq -r '.span_attributes.name')" "$BRAINTRUST_REDACTION_PLACEHOLDER"
+}
+
+it "redacts nested fields, arrays, and JSON-serialized tool arguments" t_json_redacts_nested_sensitive_fields
+it "sanitizes span names, input, output, and metadata" t_span_event_sanitizes_all_payload_sections
+
+# ---------------------------------------------------------------------------
+describe "PostToolUse security boundaries"
+# ---------------------------------------------------------------------------
+
+t_bash_hook_sanitizes_transport_logs_and_recording() {
+    local secret='sk-bt-hook-fixture-1234567890'
+    local sid='secure-bash'
+    _set_transport_secret "$secret"
+    _setup_insert_stub
+    _activate_turn "$sid"
+    export BRAINTRUST_CC_DEBUG=true
+    export BRAINTRUST_RECORD_DIR="$TEST_TMP/recording"
+
+    local command response payload
+    command="export BRAINTRUST_API_KEY=\"$secret\"; bt --api-key $secret run"
+    response=$(jq -nc --arg secret "$secret" '{stdout:("Authorization: Bearer " + $secret), password:$secret}')
+    payload=$(fixture_post_tool_use "$sid" "Bash" \
+        "$(fixture_tool_input_bash "$command")" \
+        "$response")
+
+    run_hook post_tool_use.sh "$payload"
+    assert_success "$HOOK_STATUS"
+
+    local spans requests logs recording
+    spans=$(captured_spans)
+    requests=$(cat "$CAPTURED_REQUESTS")
+    logs=$(hook_log)
+    recording=$(cat "$BRAINTRUST_RECORD_DIR/events.ndjson")
+
+    _assert_absent "$spans" "$secret" "tool span telemetry excludes the configured key"
+    _assert_absent "$requests" "$secret" "captured API payload excludes the configured key"
+    _assert_absent "$logs" "$secret" "debug and normal logs exclude the configured key"
+    _assert_absent "$recording" "$secret" "recorded hook fixture excludes the configured key"
+    assert_contains "$(echo "$spans" | jq -r '.[0].span_attributes.name')" "$BRAINTRUST_REDACTION_PLACEHOLDER" "span name uses sanitized command preview"
+    assert_eq "$(jq -s '[.[] | select(.url | test("/insert$"))][0].auth_uses_configured_api_key' "$CAPTURED_REQUESTS")" "true" "transport uses the real configured API key"
+}
+
+t_queue_and_http_boundaries_are_non_bypassable() {
+    local secret='sk-boundary-fixture-1234567890'
+    _set_transport_secret "$secret"
+    _setup_insert_stub
+    export BRAINTRUST_SYNC_QUEUE=false
+
+    # Keep the job on disk so the persisted queue payload can be inspected.
+    ensure_worker_running() { return 0; }
+
+    local event
+    event=$(jq -nc --arg secret "$secret" '{
+        id:"span-boundary",
+        span_id:"span-boundary",
+        input:{command:("OPENAI_API_KEY=" + $secret)},
+        output:{token:$secret},
+        span_attributes:{name:("Terminal: " + $secret), type:"tool"}
+    }')
+
+    enqueue_span "secure-queue" "proj-secure" "$event"
+    assert_success "$?" "enqueue accepts the event after sanitizing it"
+
+    local queue_file queue_payload
+    queue_file=$(find "$(session_queue_dir secure-queue)/pending" -name '*.json' -type f | head -1)
+    queue_payload=$(cat "$queue_file")
+    _assert_absent "$queue_payload" "$secret" "queue file excludes the raw secret"
+
+    # Pass the original unsanitized event directly to the low-level transport;
+    # its own final scrub must still prevent an outbound leak.
+    _http_insert_span "proj-secure" "$event" >/dev/null
+    assert_success "$?" "direct HTTP insertion succeeds"
+    _assert_absent "$(cat "$CAPTURED_REQUESTS")" "$secret" "outbound payload excludes the raw secret"
+    assert_eq "$(jq -s '.[-1].auth_uses_configured_api_key' "$CAPTURED_REQUESTS")" "true" "Authorization header still uses the configured key"
+}
+
+it "sanitizes Bash spans, outputs, debug logs, recordings, and API payloads" t_bash_hook_sanitizes_transport_logs_and_recording
+it "sanitizes both queue files and direct outbound requests" t_queue_and_http_boundaries_are_non_bypassable
+
+# ---------------------------------------------------------------------------
+describe "LLM conversation and sub-agent transcript sanitization"
+# ---------------------------------------------------------------------------
+
+t_stop_hook_sanitizes_accumulated_history() {
+    local secret='sk-history-fixture-1234567890'
+    local sid='secure-history'
+    _set_transport_secret "$secret"
+    _setup_insert_stub
+    _activate_turn "$sid"
+
+    local transcript="$TEST_TMP/history.jsonl"
+    {
+        jq -nc --arg secret "$secret" '{
+            type:"user", timestamp:"2026-01-01T00:00:00.000Z",
+            message:{role:"user", content:("use BRAINTRUST_API_KEY=" + $secret)}
+        }'
+        jq -nc --arg secret "$secret" '{
+            type:"assistant", requestId:"req-secret-1", timestamp:"2026-01-01T00:00:01.000Z",
+            message:{model:"claude-test", content:[{
+                type:"tool_use", id:"tool-secret", name:"Bash",
+                input:{command:("bt --api-key " + $secret), api_key:$secret}
+            }], usage:{input_tokens:5, output_tokens:5, cache_creation_input_tokens:0, cache_read_input_tokens:0}}
+        }'
+        jq -nc --arg secret "$secret" '{
+            type:"user", timestamp:"2026-01-01T00:00:02.000Z",
+            message:{content:[{type:"tool_result", tool_use_id:"tool-secret", content:("Authorization: Bearer " + $secret)}]}
+        }'
+        jq -nc --arg secret "$secret" '{
+            type:"assistant", requestId:"req-secret-2", timestamp:"2026-01-01T00:00:03.000Z",
+            message:{model:"claude-test", content:[{type:"text", text:("finished with " + $secret)}], usage:{input_tokens:4, output_tokens:4, cache_creation_input_tokens:0, cache_read_input_tokens:0}}
+        }'
+    } > "$transcript"
+
+    run_hook stop_hook.sh "$(fixture_stop "$sid" "$transcript" "final $secret")"
+    assert_success "$HOOK_STATUS"
+
+    local spans
+    spans=$(captured_spans)
+    _assert_absent "$spans" "$secret" "LLM inputs, outputs, tool arguments, and accumulated history exclude the secret"
+    assert_eq "$(echo "$spans" | jq '[.[] | select(.span_attributes.type == "llm")] | length')" "2" "LLM spans are still emitted"
+}
+
+t_subagent_transcript_spans_are_sanitized() {
+    local secret='sk-subagent-fixture-1234567890'
+    local sid='secure-subagent'
+    _set_transport_secret "$secret"
+    _setup_insert_stub
+    _activate_turn "$sid"
+
+    local main_transcript="$TEST_TMP/main.jsonl"
+    local agent_id='agent-secure'
+    local agent_transcript="$TEST_TMP/agent-${agent_id}.jsonl"
+    : > "$main_transcript"
+    {
+        jq -nc --arg secret "$secret" '{
+            type:"assistant", requestId:"agent-req-1", timestamp:"2026-01-01T00:00:00.000Z",
+            message:{model:"claude-haiku", content:[
+                {type:"text", text:("using " + $secret)},
+                {type:"tool_use", id:"agent-tool", name:"Bash", input:{command:("BRAINTRUST_API_KEY=" + $secret + " bt")}}
+            ], usage:{input_tokens:2, output_tokens:3, cache_creation_input_tokens:0, cache_read_input_tokens:0}}
+        }'
+        jq -nc --arg secret "$secret" '{
+            type:"user", timestamp:"2026-01-01T00:00:01.000Z",
+            message:{content:[{type:"tool_result", tool_use_id:"agent-tool", content:("token=" + $secret)}]}
+        }'
+        jq -nc --arg secret "$secret" '{
+            type:"assistant", requestId:"agent-req-2", timestamp:"2026-01-01T00:00:02.000Z",
+            message:{model:"claude-haiku", content:[{type:"text", text:("done " + $secret)}], usage:{input_tokens:2, output_tokens:3, cache_creation_input_tokens:0, cache_read_input_tokens:0}}
+        }'
+    } > "$agent_transcript"
+
+    local payload
+    payload=$(jq -nc \
+        --arg sid "$sid" \
+        --arg path "$main_transcript" \
+        --arg agent_id "$agent_id" \
+        '{
+            session_id:$sid,
+            transcript_path:$path,
+            tool_name:"Agent",
+            tool_input:{description:"secure agent"},
+            tool_response:{agentId:$agent_id, status:"completed"}
+        }')
+    run_hook post_tool_use.sh "$payload"
+    assert_success "$HOOK_STATUS"
+
+    local spans
+    spans=$(captured_spans)
+    _assert_absent "$spans" "$secret" "sub-agent LLM and tool spans exclude the secret"
+    assert_eq "$(echo "$spans" | jq '[.[] | select(.span_attributes.type == "llm")] | length')" "2" "sub-agent LLM span hierarchy is preserved"
+    assert_contains "$(echo "$spans" | jq -r '[.[] | select(.metadata.tool_name == "Bash")][0].span_attributes.name')" "$BRAINTRUST_REDACTION_PLACEHOLDER" "sub-agent terminal name uses a sanitized preview"
+}
+
+it "sanitizes LLM tool-call arguments and accumulated conversation history" t_stop_hook_sanitizes_accumulated_history
+it "sanitizes transcript-derived sub-agent LLM and tool spans" t_subagent_transcript_spans_are_sanitized
+
+# ---------------------------------------------------------------------------
+describe "recording fixtures"
+# ---------------------------------------------------------------------------
+
+t_recording_sanitizes_events_and_transcript_snapshots() {
+    local secret='sk-recording-fixture-1234567890'
+    _set_transport_secret "$secret"
+    export BRAINTRUST_RECORD_DIR="$TEST_TMP/recording"
+
+    local transcript="$TEST_TMP/agent-recorded.jsonl"
+    jq -nc --arg secret "$secret" '{
+        type:"assistant",
+        message:{content:[{type:"text", text:("BRAINTRUST_API_KEY=" + $secret)}], api_key:$secret}
+    }' > "$transcript"
+
+    local payload
+    payload=$(jq -nc \
+        --arg path "$transcript" \
+        --arg secret "$secret" \
+        '{
+            hook_event_name:"SubagentStop",
+            session_id:"record-secure",
+            agent_transcript_path:$path,
+            tool_response:{authorization:("Bearer " + $secret)}
+        }')
+    record_hook_input "SubagentStop" "$payload"
+
+    # Exercise the generic record-only hook as well.
+    printf '%s' "$(jq -nc --arg secret "$secret" '{hook_event_name:"PreToolUse", token:$secret}')" \
+        | bash "$HOOKS_DIR/record_event.sh" PreToolUse
+
+    local events snapshot
+    events=$(cat "$BRAINTRUST_RECORD_DIR/events.ndjson")
+    snapshot=$(cat "$BRAINTRUST_RECORD_DIR/transcripts/agent-recorded.jsonl")
+    _assert_absent "$events" "$secret" "recorded hook events exclude the secret"
+    _assert_absent "$snapshot" "$secret" "recorded transcript snapshot excludes the secret"
+    assert_contains "$events" "$BRAINTRUST_REDACTION_PLACEHOLDER"
+    assert_contains "$snapshot" "$BRAINTRUST_REDACTION_PLACEHOLDER"
+}
+
+it "sanitizes hook recording mode and copied transcript fixtures" t_recording_sanitizes_events_and_transcript_snapshots
+
+exit "$(tests_failed)"


### PR DESCRIPTION
## Summary

- Centralize credential redaction for free text, nested JSON, and span events.
- Sanitize span names, inputs, outputs, histories, logs, queue payloads, recording fixtures, and outbound requests.
- Add regression coverage and document the behavior in trace plugin version 1.5.1.

## Root cause

Raw Claude hook payloads and command previews could flow into persisted telemetry without a mandatory sanitization boundary. This allowed environment assignments such as `*_API_KEY`, authorization headers, provider tokens, and other credential-shaped values to appear in span names or event data.

## Impact

Credential values are replaced with `[REDACTED]` before telemetry is queued, logged, recorded, or sent. The configured Braintrust API key remains available only for the HTTP authorization transport.

## Testing

- `make test` — 136 passed
- `bash plugins/trace-claude-code/test/test_sanitization.sh` — 10 passed
- Shell syntax checks for hooks, tests, and helpers
- JSON manifest validation
- `git diff --check`
- Sentinel scan confirming test secrets do not reach persisted telemetry