### PR TITLE
Emit tool approval metadata for Claude tool spans

### DIFF
--- a/plugins/trace-claude-code/hooks/common.sh
+++ b/plugins/trace-claude-code/hooks/common.sh
@@ -1109,7 +1109,8 @@ emit_llm_spans_from_transcript() {
             | { kind: "tool",
                 tool_use_id: $c[0].tool_use_id,
                 ts: .timestamp,
-                output: ($c[0].content) } ];
+                output: ($c[0].content),
+                is_error: ($c[0].is_error // false) } ];
 
         (assistant_calls) as $llms
         | (tool_results) as $tools
@@ -1152,9 +1153,11 @@ emit_llm_spans_from_transcript() {
             | ( [ $resolved[] | {
                     kind: "tool",
                     ts: .res.ts,
+                    tool_use_id: .res.tool_use_id,
                     name: .tc.function.name,
                     input: (.tc.function.arguments),
-                    output: (.res.output)
+                    output: (.res.output),
+                    is_error: (.res.is_error // false)
                   } ] ) as $tool_dirs
             # History additions: the assistant message, then each tool result.
             | ( [ $assistant_msg ]
@@ -1261,9 +1264,14 @@ emit_llm_spans_from_transcript() {
                     input: (.input | (try fromjson catch .)),
                     output: .output,
                     metrics: { start: $epoch, end: $epoch },
-                    metadata: { tool_name: $tool },
+                    metadata: {
+                        tool_name: $tool,
+                        tool_call_id: .tool_use_id,
+                        tool_approval: "approved"
+                    },
                     span_attributes: { name: $name, type: "tool" }
-                }')
+                }
+                + (if .is_error then {error: (.output|tostring)} else {} end)')
         fi
 
         if [ -n "$event" ] && enqueue_span "$session_id" "$project_id" "$event"; then

--- a/plugins/trace-claude-code/hooks/hooks.json
+++ b/plugins/trace-claude-code/hooks/hooks.json
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/record_event.sh PermissionDenied",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/permission_denied.sh",
             "async": false
           }
         ]
@@ -120,7 +120,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/record_event.sh PostToolUseFailure",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/post_tool_use_failure.sh",
             "async": false
           }
         ]

--- a/plugins/trace-claude-code/hooks/permission_denied.sh
+++ b/plugins/trace-claude-code/hooks/permission_denied.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+###
+# PermissionDenied Hook - Creates a denied tool span when tied to a tool request
+###
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+debug "PermissionDenied hook triggered"
+
+tracing_enabled || { debug "Tracing disabled"; exit 0; }
+check_requirements || exit 0
+
+INPUT=$(cat)
+record_hook_input "permission_denied" "$INPUT"
+debug "PermissionDenied input: $(echo "$INPUT" | jq -c '.' 2>/dev/null | head -c 500)"
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // .tool // empty' 2>/dev/null)
+TOOL_INPUT=$(echo "$INPUT" | jq -c '.tool_input // .input // {}' 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+TOOL_CALL_ID=$(echo "$INPUT" | jq -r '.tool_use_id // empty' 2>/dev/null)
+PERMISSION_ID=$(echo "$INPUT" | jq -r '.permission_id // .permission.id // empty' 2>/dev/null)
+PERMISSION_TYPE=$(echo "$INPUT" | jq -r '.permission_type // .permission.type // empty' 2>/dev/null)
+PERMISSION_TITLE=$(echo "$INPUT" | jq -r '.permission_title // .permission.title // empty' 2>/dev/null)
+
+[ -z "$TOOL_NAME" ] && { debug "No tool name, skipping"; exit 0; }
+[ -z "$SESSION_ID" ] && { debug "No session ID, skipping"; exit 0; }
+
+ROOT_SPAN_ID=$(get_session_state "$SESSION_ID" "root_span_id")
+PROJECT_ID=$(get_session_state "$SESSION_ID" "project_id")
+TURN_SPAN_ID=$(get_session_state "$SESSION_ID" "current_turn_span_id")
+
+if [ -z "$CC_EXPERIMENT_ID" ]; then
+    CC_EXPERIMENT_ID=$(get_session_state "$SESSION_ID" "experiment_id")
+    export CC_EXPERIMENT_ID
+fi
+
+if [ -z "$TURN_SPAN_ID" ] || [ -z "$PROJECT_ID" ]; then
+    debug "No current turn for session $SESSION_ID, skipping denied tool trace"
+    exit 0
+fi
+
+SPAN_ID=$(generate_uuid)
+TIMESTAMP=$(get_timestamp)
+TOOL_TIME=$(date +%s)
+
+case "$TOOL_NAME" in
+    Bash|Terminal)
+        CMD=$(echo "$TOOL_INPUT" | jq -r '.command // empty' 2>/dev/null | head -c 50)
+        SPAN_NAME="Terminal: ${CMD:-command}"
+        ;;
+    *)
+        SPAN_NAME="$TOOL_NAME"
+        ;;
+esac
+
+EVENT=$(jq -n \
+    --arg id "$SPAN_ID" \
+    --arg root_span_id "$ROOT_SPAN_ID" \
+    --arg parent "$TURN_SPAN_ID" \
+    --arg created "$TIMESTAMP" \
+    --argjson input "$TOOL_INPUT" \
+    --arg name "$SPAN_NAME" \
+    --arg tool "$TOOL_NAME" \
+    --arg tool_call_id "$TOOL_CALL_ID" \
+    --arg permission_id "$PERMISSION_ID" \
+    --arg permission_type "$PERMISSION_TYPE" \
+    --arg permission_title "$PERMISSION_TITLE" \
+    --argjson start_time "$TOOL_TIME" \
+    --argjson end_time "$TOOL_TIME" \
+    '{
+        id: $id,
+        span_id: $id,
+        root_span_id: $root_span_id,
+        span_parents: [$parent],
+        created: $created,
+        input: $input,
+        metrics: {start: $start_time, end: $end_time},
+        metadata: ({
+            tool_name: $tool,
+            tool_approval: "denied"
+        }
+        + (if $tool_call_id != "" then {tool_call_id: $tool_call_id} else {} end)
+        + (if $permission_id != "" then {permission_id: $permission_id} else {} end)
+        + (if $permission_type != "" then {permission_type: $permission_type} else {} end)
+        + (if $permission_title != "" then {permission_title: $permission_title} else {} end)),
+        span_attributes: {name: $name, type: "tool"}
+    }')
+
+enqueue_span "$SESSION_ID" "$PROJECT_ID" "$EVENT" || { log "ERROR" "Failed to enqueue denied tool span"; exit 0; }
+
+log "INFO" "Denied tool: $SPAN_NAME (turn=$TURN_SPAN_ID)"
+exit 0

--- a/plugins/trace-claude-code/hooks/post_tool_use.sh
+++ b/plugins/trace-claude-code/hooks/post_tool_use.sh
@@ -23,6 +23,29 @@ TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 TOOL_INPUT=$(echo "$INPUT" | jq -c '.tool_input // {}' 2>/dev/null)
 TOOL_OUTPUT=$(echo "$INPUT" | jq -c '.tool_response // .output // {}' 2>/dev/null)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+TOOL_CALL_ID=$(echo "$INPUT" | jq -r '.tool_use_id // empty' 2>/dev/null)
+TOOL_FAILED=$(echo "$INPUT" | jq -r '
+    if ((.tool_response.interrupted // false) == true
+        or (.tool_response.is_error // false) == true
+        or (.tool_response.isError // false) == true
+        or (.tool_response.status // "") == "error"
+        or (.tool_response.status // "") == "failed"
+        or (.tool_response.error != null)) then
+        true
+    else
+        false
+    end
+' 2>/dev/null)
+if [ "$TOOL_FAILED" != "true" ]; then
+    TOOL_FAILED=false
+fi
+TOOL_ERROR=$(echo "$INPUT" | jq -r '
+    .tool_response.error
+    // .tool_response.stderr
+    // .tool_response.message
+    // .tool_response.output
+    // "Tool execution failed"
+' 2>/dev/null | head -n 1)
 
 # Skip if no tool name
 [ -z "$TOOL_NAME" ] && { debug "No tool name, skipping"; exit 0; }
@@ -108,6 +131,9 @@ EVENT=$(jq -n \
     --argjson output "$TOOL_OUTPUT" \
     --arg name "$SPAN_NAME" \
     --arg metadata_tool "$METADATA_TOOL_NAME" \
+    --arg tool_call_id "$TOOL_CALL_ID" \
+    --arg tool_error "$TOOL_ERROR" \
+    --argjson tool_failed "$TOOL_FAILED" \
     --arg skill_name "$SKILL_NAME" \
     --arg skill_load_trigger "$SKILL_LOAD_TRIGGER" \
     --argjson is_skill_tool "$IS_SKILL_TOOL" \
@@ -126,8 +152,10 @@ EVENT=$(jq -n \
             end: $end_time
         },
         metadata: ({
-            tool_name: $metadata_tool
+            tool_name: $metadata_tool,
+            tool_approval: "approved"
         }
+        + (if $tool_call_id != "" then {tool_call_id: $tool_call_id} else {} end)
         + (if $is_skill_tool then {
             tool_kind: "skill",
             skill_name: (if $skill_name != "" then $skill_name else null end)
@@ -137,7 +165,8 @@ EVENT=$(jq -n \
             name: $name,
             type: "tool"
         }
-    }')
+    }
+    + (if $tool_failed then {error: $tool_error} else {} end)')
 
 enqueue_span "$SESSION_ID" "$PROJECT_ID" "$EVENT" || { log "ERROR" "Failed to enqueue tool span"; exit 0; }
 

--- a/plugins/trace-claude-code/hooks/post_tool_use_failure.sh
+++ b/plugins/trace-claude-code/hooks/post_tool_use_failure.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+###
+# PostToolUseFailure Hook - Creates a failed tool span as child of current Turn
+###
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+debug "PostToolUseFailure hook triggered"
+
+tracing_enabled || { debug "Tracing disabled"; exit 0; }
+check_requirements || exit 0
+
+INPUT=$(cat)
+record_hook_input "post_tool_use_failure" "$INPUT"
+debug "PostToolUseFailure input: $(echo "$INPUT" | jq -c '.' 2>/dev/null | head -c 500)"
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // .tool // empty' 2>/dev/null)
+TOOL_INPUT=$(echo "$INPUT" | jq -c '.tool_input // .input // {}' 2>/dev/null)
+TOOL_OUTPUT=$(echo "$INPUT" | jq -c '.tool_response // .output // {}' 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+TOOL_CALL_ID=$(echo "$INPUT" | jq -r '.tool_use_id // empty' 2>/dev/null)
+TOOL_ERROR=$(echo "$INPUT" | jq -r '
+    .error
+    // .message
+    // .tool_response.error
+    // .tool_response.stderr
+    // .tool_response.message
+    // "Tool execution failed"
+' 2>/dev/null | head -n 1)
+
+[ -z "$TOOL_NAME" ] && { debug "No tool name, skipping"; exit 0; }
+[ -z "$SESSION_ID" ] && { debug "No session ID, skipping"; exit 0; }
+
+ROOT_SPAN_ID=$(get_session_state "$SESSION_ID" "root_span_id")
+PROJECT_ID=$(get_session_state "$SESSION_ID" "project_id")
+TURN_SPAN_ID=$(get_session_state "$SESSION_ID" "current_turn_span_id")
+
+if [ -z "$CC_EXPERIMENT_ID" ]; then
+    CC_EXPERIMENT_ID=$(get_session_state "$SESSION_ID" "experiment_id")
+    export CC_EXPERIMENT_ID
+fi
+
+if [ -z "$TURN_SPAN_ID" ] || [ -z "$PROJECT_ID" ]; then
+    debug "No current turn for session $SESSION_ID, skipping failed tool trace"
+    exit 0
+fi
+
+TOOL_COUNT=$(get_session_state "$SESSION_ID" "current_turn_tool_count")
+TOOL_COUNT=${TOOL_COUNT:-0}
+TOOL_COUNT=$((TOOL_COUNT + 1))
+set_session_state "$SESSION_ID" "current_turn_tool_count" "$TOOL_COUNT"
+
+SPAN_ID=$(generate_uuid)
+TIMESTAMP=$(get_timestamp)
+TOOL_TIME=$(date +%s)
+
+case "$TOOL_NAME" in
+    Read|Write|Edit|MultiEdit)
+        FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.file_path // .path // empty' 2>/dev/null)
+        if [ -n "$FILE_PATH" ]; then
+            SPAN_NAME="$TOOL_NAME: $(basename "$FILE_PATH")"
+        else
+            SPAN_NAME="$TOOL_NAME"
+        fi
+        ;;
+    Bash|Terminal)
+        CMD=$(echo "$TOOL_INPUT" | jq -r '.command // empty' 2>/dev/null | head -c 50)
+        SPAN_NAME="Terminal: ${CMD:-command}"
+        ;;
+    mcp__*)
+        SPAN_NAME=$(echo "$TOOL_NAME" | sed 's/mcp__/MCP: /' | sed 's/__/ - /')
+        ;;
+    *)
+        SPAN_NAME="$TOOL_NAME"
+        ;;
+esac
+
+EVENT=$(jq -n \
+    --arg id "$SPAN_ID" \
+    --arg root_span_id "$ROOT_SPAN_ID" \
+    --arg parent "$TURN_SPAN_ID" \
+    --arg created "$TIMESTAMP" \
+    --argjson input "$TOOL_INPUT" \
+    --argjson output "$TOOL_OUTPUT" \
+    --arg name "$SPAN_NAME" \
+    --arg tool "$TOOL_NAME" \
+    --arg tool_call_id "$TOOL_CALL_ID" \
+    --arg tool_error "$TOOL_ERROR" \
+    --argjson start_time "$TOOL_TIME" \
+    --argjson end_time "$TOOL_TIME" \
+    '{
+        id: $id,
+        span_id: $id,
+        root_span_id: $root_span_id,
+        span_parents: [$parent],
+        created: $created,
+        input: $input,
+        output: $output,
+        error: $tool_error,
+        metrics: {start: $start_time, end: $end_time},
+        metadata: ({
+            tool_name: $tool,
+            tool_approval: "approved"
+        } + (if $tool_call_id != "" then {tool_call_id: $tool_call_id} else {} end)),
+        span_attributes: {name: $name, type: "tool"}
+    }')
+
+enqueue_span "$SESSION_ID" "$PROJECT_ID" "$EVENT" || { log "ERROR" "Failed to enqueue failed tool span"; exit 0; }
+
+log "INFO" "Failed tool: $SPAN_NAME (turn=$TURN_SPAN_ID)"
+exit 0

--- a/plugins/trace-claude-code/test/helpers/fixtures.sh
+++ b/plugins/trace-claude-code/test/helpers/fixtures.sh
@@ -52,6 +52,41 @@ fixture_post_tool_use() {
         '{session_id: $s, tool_name: $t, tool_input: $i, tool_response: $r}'
 }
 
+# PostToolUseFailure payload
+#
+# Args: session_id tool_name tool_input_json error [tool_response_json]
+fixture_post_tool_use_failure() {
+    local session_id="$1"
+    local tool_name="$2"
+    local tool_input="$3"      # JSON object
+    local error="$4"
+    local tool_response="${5:-}"
+    [ -z "$tool_response" ] && tool_response="{}"
+    jq -nc \
+        --arg s "$session_id" \
+        --arg t "$tool_name" \
+        --arg e "$error" \
+        --argjson i "$tool_input" \
+        --argjson r "$tool_response" \
+        '{session_id: $s, tool_name: $t, tool_input: $i, tool_response: $r, error: $e}'
+}
+
+# PermissionDenied payload
+#
+# Args: session_id tool_name tool_input_json [tool_use_id]
+fixture_permission_denied() {
+    local session_id="$1"
+    local tool_name="$2"
+    local tool_input="$3"      # JSON object
+    local tool_use_id="${4:-}"
+    jq -nc \
+        --arg s "$session_id" \
+        --arg t "$tool_name" \
+        --arg tuid "$tool_use_id" \
+        --argjson i "$tool_input" \
+        '{session_id: $s, tool_name: $t, tool_input: $i} + (if $tuid != "" then {tool_use_id: $tuid} else {} end)'
+}
+
 # Stop payload - includes the transcript path and optionally the
 # last assistant message that Claude Code provides in real Stop events.
 #

--- a/plugins/trace-claude-code/test/test_post_tool_use.sh
+++ b/plugins/trace-claude-code/test/test_post_tool_use.sh
@@ -38,6 +38,7 @@ t_post_tool_creates_tool_span() {
     payload=$(fixture_post_tool_use "sess-pt-1" "Bash" \
         "$(fixture_tool_input_bash 'ls -la')" \
         "$(fixture_tool_response_text 'a.txt\nb.txt')")
+    payload=$(echo "$payload" | jq -c '. + {tool_use_id: "toolu_success"}')
 
     run_hook post_tool_use.sh "$payload"
     assert_success "$HOOK_STATUS"
@@ -55,6 +56,39 @@ t_post_tool_creates_tool_span() {
     # Bash spans become "Terminal: <cmd>"
     assert_contains "$name" "Terminal"
     assert_contains "$name" "ls -la"
+    assert_eq "$(echo "$tool_span" | jq -r '.metadata.tool_approval')" "approved"
+    assert_eq "$(echo "$tool_span" | jq -r '.metadata.tool_call_id')" "toolu_success"
+}
+
+t_post_tool_failure_creates_error_span() {
+    _with_turn_started "sess-pt-fail"
+
+    run_hook post_tool_use_failure.sh "$(fixture_post_tool_use_failure "sess-pt-fail" "Bash" \
+        "$(fixture_tool_input_bash 'exit 1')" \
+        "Exit code 1" \
+        "$(fixture_tool_response_text 'failed')")"
+    assert_success "$HOOK_STATUS"
+
+    local tool_span
+    tool_span=$(span_by_type "tool")
+    assert_eq "$(echo "$tool_span" | jq -r '.metadata.tool_approval')" "approved"
+    assert_eq "$(echo "$tool_span" | jq -r '.error')" "Exit code 1"
+}
+
+t_permission_denied_creates_denied_span() {
+    _with_turn_started "sess-pt-denied"
+
+    run_hook permission_denied.sh "$(fixture_permission_denied "sess-pt-denied" "Bash" \
+        "$(fixture_tool_input_bash 'rm -rf /tmp/nope')" \
+        "toolu_denied")"
+    assert_success "$HOOK_STATUS"
+
+    local tool_span
+    tool_span=$(span_by_type "tool")
+    assert_eq "$(echo "$tool_span" | jq -r '.metadata.tool_approval')" "denied"
+    assert_eq "$(echo "$tool_span" | jq -r '.metadata.tool_call_id')" "toolu_denied"
+    assert_eq "$(echo "$tool_span" | jq 'has("output")')" "false"
+    assert_eq "$(echo "$tool_span" | jq 'has("error")')" "false"
 }
 
 t_tool_span_is_child_of_turn() {
@@ -127,6 +161,8 @@ t_multiple_tools_in_turn() {
 }
 
 it "creates a tool span on PostToolUse"             t_post_tool_creates_tool_span
+it "creates an error tool span on PostToolUseFailure" t_post_tool_failure_creates_error_span
+it "creates a denied tool span on PermissionDenied" t_permission_denied_creates_denied_span
 it "tool span is a child of the current Turn span"  t_tool_span_is_child_of_turn
 it "Read tool span name includes file basename"     t_read_tool_span_name_includes_basename
 it "Skill tool span marks tool kind"                t_skill_tool_span_marks_tool_kind
@@ -207,7 +243,7 @@ t_agent_emits_subagent_llm_spans() {
     {
         # r1: text + a tool_use (Bash) -> emits an LLM span and a tool span.
         echo '{"type":"assistant","requestId":"r1","timestamp":"2026-06-11T03:00:00.000Z","message":{"model":"claude-haiku-4-5","content":[{"type":"text","text":"hi"},{"type":"tool_use","id":"tu1","name":"Bash","input":{"command":"ls -la"}}],"usage":{"input_tokens":5,"output_tokens":40,"cache_creation_input_tokens":10,"cache_read_input_tokens":1000}}}'
-        echo '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu1","content":"a.txt"}]}}'
+        echo '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu1","content":"Exit code 128","is_error":true}]}}'
         # r2: final text answer -> emits a second LLM span (with history).
         echo '{"type":"assistant","requestId":"r2","timestamp":"2026-06-11T03:00:02.000Z","message":{"model":"claude-haiku-4-5","content":[{"type":"text","text":"bye"}],"usage":{"input_tokens":3,"output_tokens":20,"cache_creation_input_tokens":5,"cache_read_input_tokens":1500}}}'
     } > "$agent_transcript"
@@ -250,6 +286,9 @@ t_agent_emits_subagent_llm_spans() {
     subagent_tool=$(all_spans | jq --arg p "$agent_span_id" \
         '[.[]|select(.span_attributes.type=="tool" and .span_parents[0]==$p)][0]')
     assert_eq "$(echo "$subagent_tool" | jq -r '.span_attributes.name')" "Terminal: ls -la" "sub-agent tool span named after the Bash command"
+    assert_eq "$(echo "$subagent_tool" | jq -r '.metadata.tool_approval')" "approved" "sub-agent tool approval state"
+    assert_eq "$(echo "$subagent_tool" | jq -r '.metadata.tool_call_id')" "tu1" "sub-agent tool call id"
+    assert_eq "$(echo "$subagent_tool" | jq -r '.error')" "Exit code 128" "sub-agent tool error text"
 
     # Token totals match the deduped transcript. Braintrust prompt_tokens are
     # inclusive for Anthropic: input 8 + cache_read 2500 + cache_creation 15 = 2523.


### PR DESCRIPTION
## Summary
- Emit `metadata.tool_approval = "approved"` for executed Claude tool spans and `"denied"` for permission-denied spans.
- Keep failed tool executions marked with the top-level `error` field.
- Update shell hook tests and subagent replay assertions for the approval metadata contract.

## Validation
- bash plugins/trace-claude-code/test/test_post_tool_use.sh
- make test